### PR TITLE
1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,3 +99,19 @@
 
 ### Added
 * CHANGELOG file
+
+## [1.3.0] - 2021-07-08
+
+### Added
+* Code for cleaning up AWS resources created by Assisted Log Enabler for AWS.
+    * Amazon Route 53 Resolver Query Logging in single account mode is only currently supported.
+* Options for running cleanup mode within the main function.
+* IAM Permissions example for cleanup operations.
+* Information within the Step-by-Step instructions for multi-account to reflect details about AWS CloudFormation StackSets Delegated Administrator.
+
+### Changed
+* README documentation.
+    * Updated Cleanup section to reflect new cleanup capabilities.
+    * Updated IAM Permissions examples within the README.
+* AWS CloudFormation template for deploying IAM Permissions to run cleanup code.
+* Header in files to reflect "Assisted Log Enabler for AWS", instead of "Assisted Log Enabler (ALE)".

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The following is a simple diagram on how Assisted Log Enabler for AWS works in a
 
 ## Prerequisites
 ### Permissions
-The following permissions are needed within AWS IAM for Assisted Log Enabler for AWS to run:
+The following permissions are needed within AWS IAM for Assisted Log Enabler for AWS to run. Please see each section for a breakdown per AWS Service and functionality:
 ```
+# All permissions used within Assisted Log Enabler for AWS:
 "ec2:DescribeVpcs",
 "ec2:DescribeFlowLogs",
 "ec2:CreateFlowLogs",
@@ -42,7 +43,55 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "route53resolver:ListResolverQueryLogConfigAssociations",
 "route53resolver:CreateResolverQueryLogConfig",
 "route53resolver:AssociateResolverQueryLogConfig",
+"iam:CreateServiceLinkRole", # This is used to create the AWSServiceRoleForRoute53 Resolver, which is used for creating the Amazon Route 53 Query Logging Configurations.
+"route53resolver:ListResolverQueryLogConfigs",
+"route53resolver:ListTagsForResource",
+"route53resolver:DisassociateResolverQueryLogConfig",
+"route53resolver:DeleteResolverQueryLogConfig"
+
+# For adding AWS CloudTrail logs:
+"s3:GetBucketPolicy",
+"s3:PutBucketPolicy",
+"s3:PutLifecycleConfiguration"
+"s3:PutObject",
+"s3:CreateBucket",
+"cloudtrail:StartLogging",
+"cloudtrail:CreateTrail",
+"cloudtrail:DescribeTrails"
+
+# For adding Amazon VPC Flow Logs:
+"s3:GetBucketPolicy",
+"s3:PutBucketPolicy",
+"s3:PutLifecycleConfiguration"
+"s3:PutObject",
+"s3:CreateBucket",
+"ec2:DescribeVpcs",
+"ec2:DescribeFlowLogs",
+"ec2:CreateFlowLogs"
+
+# For adding Amazon EKS logs:
+"eks:UpdateClusterConfig",
+"eks:ListClusters",
+"logs:CreateLogDelivery"
+
+# For adding Amazon Route 53 Resolver Query Logs:
+"s3:GetBucketPolicy",
+"s3:PutBucketPolicy",
+"s3:PutLifecycleConfiguration"
+"s3:PutObject",
+"s3:CreateBucket",
+"ec2:DescribeVpcs",
+"route53resolver:ListResolverQueryLogConfigAssociations",
+"route53resolver:CreateResolverQueryLogConfig",
+"route53resolver:AssociateResolverQueryLogConfig",
 "iam:CreateServiceLinkRole" # This is used to create the AWSServiceRoleForRoute53 Resolver, which is used for creating the Amazon Route 53 Query Logging Configurations.
+
+# NEW! For cleanup of Amazon Route 53 Resolver Query Logs created by Assisted Log Enabler for AWS:
+"route53resolver:ListResolverQueryLogConfigs",
+"route53resolver:ListTagsForResource",
+"route53resolver:ListResolverQueryLogConfigAssociations",
+"route53resolver:DisassociateResolverQueryLogConfig",
+"route53resolver:DeleteResolverQueryLogConfig"
 ```
 Additionally, if running from within a AWS Lambda function, the function will need the AWSLambdaBasicExecutionRole in order to run successfully. Please refer to the following link for more details: https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html
 
@@ -154,6 +203,7 @@ python3 assisted_log_enabler.py --mode single_account --cloudtrail
 ### Step-by-Step Instructions (for running in AWS CloudShell, multi account mode)
 1. Log into the AWS Console of the account you want to run the Assisted Log Enabler for AWS.
    * Ensure that the AWS Account you're in is the account you want to store the logs. Additionally, ensure that the AWS account you're in has access to the AWS Organizations information within your AWS environment.
+   * You may have to register your AWS account as a delegated administrator within AWS CloudFormation, in order to run this code in an AWS account of your choosing. Please see the following link for more details: [Register a delegated administrator](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 2. Within the AWS Console, go to AWS CloudFormation.
 3. Within AWS CloudFormation, go to StackSets.
 4. Within the StackSets screen, select Create StackSet.
@@ -224,6 +274,12 @@ Once the logs have been enabled, you can safely remove any of the downloaded fil
 * Note: The log file containing the detailed output of actions will be in the root directory of the Assisted Log Enabler for AWS tool. If you want to retain this, please download this to a safe place, either locally or to an Amazon S3 bucket, for your records. For information on how to download files from AWS CloudShell sessions, refer to the following [link](https://docs.aws.amazon.com/cloudshell/latest/userguide/working-with-cloudshell.html#files-storage).
 
 For any AWS IAM Roles that are created, either manually or using AWS CloudFormation StackSets, those can be safely deleted upon enablement of logs through the Assisted Log Enabler for AWS.
+
+NEW! A cleanup mode is available within the Assisted Log Enabler for AWS (currently only for single account, Amazon Route 53 Resover Query Logs). Collected logs within Amazon S3 will NOT be removed, however, logging resources can be removed by following the below commands:
+```
+# To remove Amazon Route 53 Resolver Query Logs (single account):
+python3 assisted_log_enabler.py --mode cleanup --single_r53querylogs
+```
 
 
 ## Costs

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -1,6 +1,6 @@
 #// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #// SPDX-License-Identifier: Apache-2.0
-# Assisted Log Enabler (ALE) - Find resources that are not logging, and turn them on.
+# Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
 # Joshua "DozerCat" McKiddy - Team DragonCat - AWS
 
 import logging
@@ -16,6 +16,7 @@ from datetime import timezone
 
 from subfunctions import ALE_multi_account
 from subfunctions import ALE_single_account
+from subfunctions import ALE_cleanup_single
 
 
 current_date = datetime.datetime.now(tz=timezone.utc)
@@ -81,6 +82,9 @@ def assisted_log_enabler():
     function_parser_group.add_argument('--r53querylogs', action='store_true', help=' Turns on Amazon Route 53 Resolver Query Logs.')
     function_parser_group.add_argument('--cloudtrail', action='store_true', help=' Turns on AWS CloudTrail.')
 
+    cleanup_parser_group = parser.add_argument_group('Cleanup Options', 'Use these flags to choose which resources you want to turn logging off for.')
+    cleanup_parser_group.add_argument('--single_r53querylogs', action='store_true', help=' Turns on Amazon Route 53 Resolver Query Logs.')
+
     args = parser.parse_args()
     banner()
 
@@ -110,6 +114,9 @@ def assisted_log_enabler():
             ALE_multi_account.lambda_handler(event, context)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
+    elif args.mode == 'cleanup':
+        if args.single_r53querylogs:
+            ALE_cleanup_single.run_r53_cleanup()
     else:
         print("No valid option selected. Please run with -h to display valid options.")
 

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -1,6 +1,6 @@
 #// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #// SPDX-License-Identifier: Apache-2.0
-# Assisted Log Enabler (ALE) - Find resources that are not logging, and turn them on.
+# Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
 # Joshua "DozerCat" McKiddy - Team DragonCat - AWS
 # This sample template is for creating an IAM Role within child accounts, for the purpose of running Assisted Log Enabler across a multi-account environment.
 
@@ -61,6 +61,17 @@ Resources:
             Condition:
               StringLike:
                 'iam:AWSServiceName': 'route53resolver.amazonaws.com'
+          - Effect: Allow
+            Action:
+              - route53resolver:ListResolverQueryLogConfigs
+              - route53resolver:ListTagsForResource
+              - route53resolver:ListResolverQueryLogConfigAssociations
+              - route53resolver:DisassociateResolverQueryLogConfig
+              - route53resolver:DeleteResolverQueryLogConfig
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'aws:PrincipalOrgId': !Ref OrgId
 
   AssistedLogEnablerRole:
     Type: AWS::IAM::Role

--- a/permissions/ALE_permissions_example_cleanup_single.json
+++ b/permissions/ALE_permissions_example_cleanup_single.json
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
+// Joshua "DozerCat" McKiddy - Team DragonCat - AWS
+
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AssistedLogEnablerCleanup1",
+            "Effect": "Allow",
+            "Action": [
+                "route53resolver:ListResolverQueryLogConfigs",
+                "route53resolver:ListTagsForResource",
+                "route53resolver:ListResolverQueryLogConfigAssociations",
+                "route53resolver:DisassociateResolverQueryLogConfig",
+                "route53resolver:DeleteResolverQueryLogConfig"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "<enter_account_number_here>"
+                }
+            }
+        }
+    ]
+}

--- a/permissions/ALE_permissions_example_single_account.json
+++ b/permissions/ALE_permissions_example_single_account.json
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-// Assisted Log Enabler (ALE) - Find resources that are not logging, and turn them on.
+// Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
 // Joshua "DozerCat" McKiddy - Team DragonCat - AWS
 
 {
@@ -27,7 +27,6 @@
                 "route53resolver:ListResolverQueryLogConfigAssociations",
                 "route53resolver:CreateResolverQueryLogConfig",
                 "route53resolver:AssociateResolverQueryLogConfig"
-
             ],
             "Resource": "*",
             "Condition": {

--- a/subfunctions/ALE_cleanup_single.py
+++ b/subfunctions/ALE_cleanup_single.py
@@ -1,0 +1,130 @@
+#// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#// SPDX-License-Identifier: Apache-2.0
+# Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
+# Joshua "DozerCat" McKiddy - Team DragonCat - AWS
+
+
+import logging
+import os
+import json
+import boto3
+import time
+import datetime
+from botocore.exceptions import ClientError
+from datetime import timezone
+
+
+current_date = datetime.datetime.now(tz=timezone.utc)
+current_date_string = str(current_date)
+timestamp_date = datetime.datetime.now(tz=timezone.utc).strftime("%Y-%m-%d-%H%M%S")
+timestamp_date_string = str(timestamp_date)
+
+
+logFormatter = '%(asctime)s - %(levelname)s - %(message)s'
+logging.basicConfig(format=logFormatter, level=logging.INFO)
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+output_handle = logging.FileHandler('ALE_' + timestamp_date_string + '.log')
+output_handle.setLevel(logging.INFO)
+logger.addHandler(output_handle)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+output_handle.setFormatter(formatter)
+
+
+region = os.environ['AWS_REGION']
+
+
+region_list = ['af-south-1', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'eu-south-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
+
+
+# 1. Remove the Route 53 Resolver Query Logging Resources created by Assisted Log Enabler
+def r53_cleanup():
+    """Function to clean up Route 53 Query Logging Resources"""
+    for aws_region in region_list:
+        logging.info("---- LINE BREAK BETWEEN REGIONS ----")
+        logging.info("Cleaning up Route 53 Query Logging Resources in region " + aws_region + ".")
+        route53resolver = boto3.client('route53resolver', region_name=aws_region)
+        try:
+            QueryLogList: list = []
+            QueryLogArnRemoveList: list = []
+            QueryLogIdRemoveList: list = []
+            logging.info("ListResolverQueryLogConfigs API Call")
+            ale_r53_logs = route53resolver.list_resolver_query_log_configs() # Collecting Arn of all Query Logs
+            for r53_arn in ale_r53_logs['ResolverQueryLogConfigs']:
+                QueryLogList.append(r53_arn['Arn'])
+            for r53_tag_info in QueryLogList:
+                logging.info("Listing Tags for " + r53_tag_info)
+                logging.info("ListTagsForResource API Call")
+                r53_tags = route53resolver.list_tags_for_resource( # Looking at tags for each Arn collected
+                    ResourceArn=r53_tag_info
+                )
+                for value in r53_tags['Tags']:
+                    if (value['Key'] == 'Workflow' and value['Value'] == 'assisted-log-enabler'):
+                        logging.info("The following Route 53 Query Logger was created by Assisted Log Enabler for AWS, and will be removed within this function: " + r53_tag_info)
+                        QueryLogArnRemoveList.append(r53_tag_info)
+            for Id in QueryLogArnRemoveList:
+                logging.info("Gathering Resource ID for Route 53 Query Logging Resource to be removed.")
+                logging.info("ListResolverQueryLogConfigs API Call")
+                r53_resource_id = route53resolver.list_resolver_query_log_configs()['ResolverQueryLogConfigs'][QueryLogArnRemoveList.index(Id)]['Id'] # Collecting Resource ID for each Arn collected
+                QueryLogIdRemoveList.append(r53_resource_id)
+                logging.info(r53_resource_id + " added to removal list.")
+            logging.info("The following Resource IDs were created by Assisted Log Enabler for AWS, and will be removed within this function.")
+            print(QueryLogIdRemoveList)
+            for r53_remove in QueryLogIdRemoveList:
+                logging.info("Gathering Query Log Config Associations for " + r53_remove)
+                logging.info("ListResolverQueryLogConfigAssociations API Call")
+                associated_vpcs = route53resolver.list_resolver_query_log_config_associations(
+                )
+                if associated_vpcs['TotalCount'] > 0 and associated_vpcs['ResolverQueryLogConfigAssociations'][0]['ResolverQueryLogConfigId'] == r53_remove:
+                    logging.info("The following Route 53 Query Logger is associated with a VPC, and will be removed within this function: " + r53_remove)
+                    VPCRemovalList = []
+                    for vpc_info in associated_vpcs['ResolverQueryLogConfigAssociations']:
+                        VPCRemovalList.append(vpc_info['ResourceId'])
+                    logging.info("List of VPCs to be disassociated:")
+                    print(VPCRemovalList)
+                    for vpc in VPCRemovalList:
+                        logging.info("Removing " + vpc + " from Route 53 Query Logging configuration " + r53_remove)
+                        logging.info("DisassociateResolverQueryLogConfig API Call")
+                        removing_vpc = route53resolver.disassociate_resolver_query_log_config(
+                            ResolverQueryLogConfigId=r53_remove,
+                            ResourceId=vpc
+                        )
+                        logging.info(vpc + " removed from " + r53_remove)
+                        time.sleep(1)
+                    logging.info("60 second pause to ensure disassociation of Amazon VPCs...")
+                    time.sleep(60)
+                    logging.info("Removing Route 53 Query Logger: " + r53_remove)
+                    logging.info("DeleteResolverQueryLogConfig")
+                    r53_cleanup = route53resolver.delete_resolver_query_log_config(
+                        ResolverQueryLogConfigId=r53_remove
+                    )
+                    logging.info(r53_remove + " has been removed.")
+                    time.sleep(2)
+                else:
+                    logging.info("Removing Route 53 Query Logger: " + r53_remove)
+                    logging.info("DeleteResolverQueryLogConfig")
+                    r53_cleanup = route53resolver.delete_resolver_query_log_config(
+                        ResolverQueryLogConfigId=r53_remove
+                    )
+                    logging.info(r53_remove + " has been removed.")
+                    time.sleep(2)
+        except Exception as exception_handle:
+            logging.error(exception_handle)
+
+
+def run_r53_cleanup():
+    """Function to run the r53_cleanup function"""
+    r53_cleanup()
+    logging.info("This is the end of the script. Please feel free to validate that logging resources have been cleaned up.")
+
+
+def lambda_handler(event, context):
+    """Function that runs all of the previously defined functions"""
+    r53_cleanup()
+    logging.info("This is the end of the script. Please feel free to validate that logging resources have been cleaned up.")
+
+
+if __name__ == '__main__':
+   event = "event"
+   context = "context"
+   lambda_handler(event, context)

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -1,6 +1,6 @@
 #// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #// SPDX-License-Identifier: Apache-2.0
-# Assisted Log Enabler (ALE) - Find resources that are not logging, and turn them on.
+# Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
 # Joshua "DozerCat" McKiddy - Team DragonCat - AWS
 
 

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -1,6 +1,6 @@
 #// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #// SPDX-License-Identifier: Apache-2.0
-# Assisted Log Enabler (ALE) - Find resources that are not logging, and turn them on.
+# Assisted Log Enabler for AWS - Find resources that are not logging, and turn them on.
 # Joshua "DozerCat" McKiddy - Team DragonCat - AWS
 
 
@@ -256,8 +256,8 @@ def route_53_query_logs(region_list, account_number):
             logging.info("Route 53 Query Logging Created. Resource ID:" + r53_query_log_id)
             for vpc in r53_working_list:
                 logging.info("Associating " + vpc + " with the created Route 53 Query Logging.")
-                logging.info("AssocateResolverQueryLogConfig")
-                activate_r5_logs = route53resolver.associate_resolver_query_log_config(
+                logging.info("AssociateResolverQueryLogConfig")
+                activate_r53_logs = route53resolver.associate_resolver_query_log_config(
                     ResolverQueryLogConfigId=r53_query_log_id,
                     ResourceId=vpc
                 )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/assisted-log-enabler-for-aws/issues/16
*Description of changes:*
### Added
* Code for cleaning up AWS resources created by Assisted Log Enabler for AWS.
    * Amazon Route 53 Resolver Query Logging in single account mode is only currently supported.
* Options for running cleanup mode within the main function.
* IAM Permissions example for cleanup operations.
* Information within the Step-by-Step instructions for multi-account to reflect details about AWS CloudFormation StackSets Delegated Administrator.

### Changed
* README documentation.
    * Updated Cleanup section to reflect new cleanup capabilities.
    * Updated IAM Permissions examples within the README.
* AWS CloudFormation template for deploying IAM Permissions to run cleanup code.
* Header in files to reflect "Assisted Log Enabler for AWS", instead of "Assisted Log Enabler (ALE)".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
