### PR TITLE
Extended --bucket option to multi_account mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "ec2:DescribeVpcs",
 "ec2:DescribeFlowLogs",
 "ec2:CreateFlowLogs",
+"ec2:CreateTags",
 "logs:CreateLogDelivery",
 "s3:GetBucketPolicy",
 "s3:PutBucketPolicy",
@@ -53,6 +54,7 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "route53resolver:ListResolverQueryLogConfigAssociations",
 "route53resolver:CreateResolverQueryLogConfig",
 "route53resolver:AssociateResolverQueryLogConfig",
+"route53resolver:TagResource",
 "iam:CreateServiceLinkRole", # This is used to create the AWSServiceRoleForRoute53 Resolver, which is used for creating the Amazon Route 53 Query Logging Configurations.
 "route53resolver:ListResolverQueryLogConfigs",
 "route53resolver:ListTagsForResource",
@@ -86,7 +88,8 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "s3:CreateBucket",
 "ec2:DescribeVpcs",
 "ec2:DescribeFlowLogs",
-"ec2:CreateFlowLogs"
+"ec2:CreateFlowLogs",
+"ec2:CreateTags"
 
 # For adding Amazon EKS logs:
 "eks:UpdateClusterConfig",
@@ -103,6 +106,7 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "route53resolver:ListResolverQueryLogConfigAssociations",
 "route53resolver:CreateResolverQueryLogConfig",
 "route53resolver:AssociateResolverQueryLogConfig",
+"route53resolver:TagResource",
 "iam:CreateServiceLinkRole" # This is used to create the AWSServiceRoleForRoute53 Resolver, which is used for creating the Amazon Route 53 Query Logging Configurations.
 
 # For adding Amazon S3 Server Access Logs:
@@ -194,12 +198,13 @@ No valid option selected. Please run with -h to display valid options.
 * Options
 ```
 python3 assisted_log_enabler.py -h
-usage: assisted_log_enabler.py [-h] [--mode MODE] [--all] [--eks] [--vpcflow]
-                               [--r53querylogs] [--s3logs] [--lblogs] [--cloudtrail]
+usage: assisted_log_enabler.py [-h] [--mode MODE] [--bucket BUCKET] [--all]
+                               [--eks] [--vpcflow] [--r53querylogs] [--s3logs]
+                               [--lblogs] [--cloudtrail]
                                [--single_r53querylogs] [--single_cloudtrail]
                                [--single_vpcflow] [--single_all]
-                               [--single_s3logs] [--single_lblogs] [--single_account]
-                               [--multi_account]
+                               [--single_s3logs] [--single_lblogs]
+                               [--single_account] [--multi_account]
 
 Assisted Log Enabler - Find resources that are not logging, and turn them on.
 
@@ -211,6 +216,11 @@ optional arguments:
                         multi_account, You must have the associated
                         CloudFormation template deployed as a StackSet. See
                         the README file for more details.
+  --bucket BUCKET       Specify an S3 bucket name that you want Assisted Log
+                        Enabler to store logs in. Otherwise, a new S3 bucket
+                        will be created (default). Only used for Amazon VPC
+                        Flow Logs, Amazon Route 53 Resolver Query Logs, and
+                        AWS CloudTrail logs.
 
 Single & Multi Account Options:
   Use these flags to choose which services you want to turn logging on for.
@@ -221,8 +231,9 @@ Single & Multi Account Options:
   --vpcflow             Turns on Amazon VPC Flow Logs.
   --r53querylogs        Turns on Amazon Route 53 Resolver Query Logs.
   --s3logs              Turns on Amazon Bucket Logs.
-  --lblogs              Turns on Elastic Load Balancing Logs.
-  --cloudtrail          Turns on AWS CloudTrail.
+  --lblogs              Turns on Amazon Load Balancer Logs.
+  --cloudtrail          Turns on AWS CloudTrail. Only available in Single
+                        Account version.
 
 Cleanup Options:
   Use these flags to choose which resources you want to turn logging off
@@ -239,7 +250,7 @@ Cleanup Options:
                         Enabler for AWS.
   --single_s3logs       Removes Amazon Bucket Log resources created by
                         Assisted Log Enabler for AWS.
-  --single_lblogs       Removes Elastic Load Balancing Log resources created by
+  --single_lblogs       Removes Amazon Load Balancer Log resources created by
                         Assisted Log Enabler for AWS.
 
 Dry Run Options:

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ optional arguments:
                         Enabler to store logs in. Otherwise, a new S3 bucket
                         will be created (default). Only used for Amazon VPC
                         Flow Logs, Amazon Route 53 Resolver Query Logs, and
-                        AWS CloudTrail logs.
+                        AWS CloudTrail logs. WARNING: For multi_account, this
+                        will replace the bucket policy. For single_account,
+                        this may add statements to the bucket policy.
 
 Single & Multi Account Options:
   Use these flags to choose which services you want to turn logging on for.

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -75,7 +75,8 @@ def assisted_log_enabler():
 
     parser = argparse.ArgumentParser(description='Assisted Log Enabler - Find resources that are not logging, and turn them on.')
     parser.add_argument('--mode',help=' Choose the mode that you want to run Assisted Log Enabler in. Available modes: single_account, multi_account, cleanup, dryrun. WARNING: For multi_account, You must have the associated CloudFormation template deployed as a StackSet. See the README file for more details.')
-    
+    parser.add_argument('--bucket',help=' Specify an S3 bucket name that you want Assisted Log Enabler to store logs in. Otherwise, a new S3 bucket will be created (default). Only used for Amazon VPC Flow Logs, Amazon Route 53 Resolver Query Logs, and AWS CloudTrail logs. WARNING: For multi_account, this will replace the bucket policy. For single_account, this may add statements to the bucket policy.')
+
     function_parser_group = parser.add_argument_group('Single & Multi Account Options', 'Use these flags to choose which services you want to turn logging on for.')
     function_parser_group.add_argument('--all', action='store_true', help=' Turns on all of the log types within the Assisted Log Enabler for AWS.')
     function_parser_group.add_argument('--eks', action='store_true', help=' Turns on Amazon EKS audit & authenticator logs.')
@@ -102,36 +103,41 @@ def assisted_log_enabler():
 
     event = 'event'
     context = 'context'
+    bucket_name = 'default'
     if args.mode == 'single_account':
+        if args.bucket:
+            bucket_name = args.bucket
         if args.eks:
             ALE_single_account.run_eks()
         elif args.vpcflow:
-            ALE_single_account.run_vpc_flow_logs()
+            ALE_single_account.run_vpc_flow_logs(bucket_name)
         elif args.r53querylogs:
-            ALE_single_account.run_r53_query_logs()
+            ALE_single_account.run_r53_query_logs(bucket_name)
         elif args.s3logs:
             ALE_single_account.run_s3_logs()
         elif args.lblogs:
             ALE_single_account.run_lb_logs()
         elif args.cloudtrail:
-            ALE_single_account.run_cloudtrail()
+            ALE_single_account.run_cloudtrail(bucket_name)
         elif args.all:
-            ALE_single_account.lambda_handler(event, context)
+            ALE_single_account.lambda_handler(event, context, bucket_name)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'multi_account':
+        if args.bucket:
+            bucket_name = args.bucket
         if args.eks:
             ALE_multi_account.run_eks()
         elif args.vpcflow:
-            ALE_multi_account.run_vpc_flow_logs()
+            ALE_multi_account.run_vpc_flow_logs(bucket_name)
         elif args.r53querylogs:
-            ALE_multi_account.run_r53_query_logs()
+            ALE_multi_account.run_r53_query_logs(bucket_name)
         elif args.s3logs:
             ALE_multi_account.run_s3_logs()
         elif args.lblogs:
             ALE_multi_account.run_lb_logs()
         elif args.all:
-            ALE_multi_account.lambda_handler(event, context)
+            ALE_multi_account.lambda_handler(event, context, bucket_name)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'cleanup':

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -50,6 +50,7 @@ Resources:
               - route53resolver:ListResolverQueryLogConfigAssociations
               - route53resolver:CreateResolverQueryLogConfig
               - route53resolver:AssociateResolverQueryLogConfig
+              - route53resolver:TagResource
               - s3:PutBucketLogging
               - s3:GetBucketLogging
               - s3:ListBucket
@@ -69,6 +70,7 @@ Resources:
               - elasticloadbalancing:DescribeLoadBalancerAttributes
               - elasticloadbalancing:ModifyLoadBalancerAttributes
               - eks:ListClusters
+              - ec2:CreateTags
             Resource: '*'
             Condition:
               StringEquals:


### PR DESCRIPTION
Issue #37 - Enable ability to use preexisting S3 bucket

Extended `--bucket` functionality to multi_account mode. Now works for `--vpcflow` and `--r53querylogs` log sources. When bucket is specified, the bucket policy is replaced to allow cross-account support. 

Updated `ALE_child_account_role.yaml` and `README.md` to include permissions necessary for vpcflow and r53querylogs in multi_account mode.

Bug fix: Added tagging to `flow_log_activator` function in `ALE_multi_account.py` which allows cleanup mode to detect and remove any VPC flow logs created by ALE. Previously, multi_account mode did not tag VPC flow logs it created, resulting in cleanup mode not deleting the logs. Permissions to make this possible were included in the ALE role template.

This pull request builds off of #45. The same single_account mode functionality is included in this pull request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
