### PR TITLE
--guardduty exports findings to an S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ No valid option selected. Please run with -h to display valid options.
 * Options
 ```
 python3 assisted_log_enabler.py -h
-usage: assisted_log_enabler.py [-h] [--mode MODE] [--bucket BUCKET] [--all]
+usage: assisted_log_enabler.py [-h] [--mode MODE] [--bucket BUCKET]
+                               [--include_accounts ACCOUNT_NUMBERS]
+                               [--exclude_accounts ACCOUNT_NUMBERS] [--all]
                                [--eks] [--vpcflow] [--r53querylogs] [--s3logs]
                                [--lblogs] [--cloudtrail]
                                [--single_r53querylogs] [--single_cloudtrail]
@@ -216,13 +218,20 @@ optional arguments:
                         multi_account, You must have the associated
                         CloudFormation template deployed as a StackSet. See
                         the README file for more details.
-  --bucket BUCKET       Specify an S3 bucket name that you want Assisted Log
-                        Enabler to store logs in. Otherwise, a new S3 bucket
-                        will be created (default). Only used for Amazon VPC
-                        Flow Logs, Amazon Route 53 Resolver Query Logs, and
-                        AWS CloudTrail logs. WARNING: For multi_account, this
-                        will replace the bucket policy. For single_account,
-                        this may add statements to the bucket policy.
+  --bucket BUCKET       Specify the name of a pre-existing S3 bucket that you
+                        want Assisted Log Enabler to store logs in. Otherwise,
+                        a new S3 bucket will be created (default). Only used
+                        for Amazon VPC Flow Logs, Amazon Route 53 Resolver
+                        Query Logs, and AWS CloudTrail logs. WARNING: For
+                        multi_account, this will replace the bucket policy.
+                        For single_account, this may add statements to the
+                        bucket policy.
+  --include_accounts ACCOUNT_NUMBERS
+                        Specify a comma separated list of AWS account numbers
+                        to INCLUDE for multi_account mode.
+  --exclude_accounts ACCOUNT_NUMBERS
+                        Specify a comma separated list of AWS account numbers
+                        to EXCLUDE for multi_account mode.
 
 Single & Multi Account Options:
   Use these flags to choose which services you want to turn logging on for.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "ec2:DescribeVpcs",
 "ec2:DescribeFlowLogs",
 "ec2:CreateFlowLogs",
+"ec2:CreateTags",
 "logs:CreateLogDelivery",
 "s3:GetBucketPolicy",
 "s3:PutBucketPolicy",
@@ -53,6 +54,7 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "route53resolver:ListResolverQueryLogConfigAssociations",
 "route53resolver:CreateResolverQueryLogConfig",
 "route53resolver:AssociateResolverQueryLogConfig",
+"route53resolver:TagResource",
 "iam:CreateServiceLinkRole", # This is used to create the AWSServiceRoleForRoute53 Resolver, which is used for creating the Amazon Route 53 Query Logging Configurations.
 "route53resolver:ListResolverQueryLogConfigs",
 "route53resolver:ListTagsForResource",
@@ -86,7 +88,8 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "s3:CreateBucket",
 "ec2:DescribeVpcs",
 "ec2:DescribeFlowLogs",
-"ec2:CreateFlowLogs"
+"ec2:CreateFlowLogs",
+"ec2:CreateTags"
 
 # For adding Amazon EKS logs:
 "eks:UpdateClusterConfig",
@@ -103,6 +106,7 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "route53resolver:ListResolverQueryLogConfigAssociations",
 "route53resolver:CreateResolverQueryLogConfig",
 "route53resolver:AssociateResolverQueryLogConfig",
+"route53resolver:TagResource",
 "iam:CreateServiceLinkRole" # This is used to create the AWSServiceRoleForRoute53 Resolver, which is used for creating the Amazon Route 53 Query Logging Configurations.
 
 # For adding Amazon S3 Server Access Logs:
@@ -194,12 +198,13 @@ No valid option selected. Please run with -h to display valid options.
 * Options
 ```
 python3 assisted_log_enabler.py -h
-usage: assisted_log_enabler.py [-h] [--mode MODE] [--all] [--eks] [--vpcflow]
-                               [--r53querylogs] [--s3logs] [--lblogs] [--cloudtrail]
+usage: assisted_log_enabler.py [-h] [--mode MODE] [--bucket BUCKET] [--all]
+                               [--eks] [--vpcflow] [--r53querylogs] [--s3logs]
+                               [--lblogs] [--cloudtrail]
                                [--single_r53querylogs] [--single_cloudtrail]
                                [--single_vpcflow] [--single_all]
-                               [--single_s3logs] [--single_lblogs] [--single_account]
-                               [--multi_account]
+                               [--single_s3logs] [--single_lblogs]
+                               [--single_account] [--multi_account]
 
 Assisted Log Enabler - Find resources that are not logging, and turn them on.
 
@@ -211,6 +216,11 @@ optional arguments:
                         multi_account, You must have the associated
                         CloudFormation template deployed as a StackSet. See
                         the README file for more details.
+  --bucket BUCKET       Specify an S3 bucket name that you want Assisted Log
+                        Enabler to store logs in. Otherwise, a new S3 bucket
+                        will be created (default). Only used for Amazon VPC
+                        Flow Logs, Amazon Route 53 Resolver Query Logs, and
+                        AWS CloudTrail logs.
 
 Single & Multi Account Options:
   Use these flags to choose which services you want to turn logging on for.
@@ -221,8 +231,9 @@ Single & Multi Account Options:
   --vpcflow             Turns on Amazon VPC Flow Logs.
   --r53querylogs        Turns on Amazon Route 53 Resolver Query Logs.
   --s3logs              Turns on Amazon Bucket Logs.
-  --lblogs              Turns on Elastic Load Balancing Logs.
-  --cloudtrail          Turns on AWS CloudTrail.
+  --lblogs              Turns on Amazon Load Balancer Logs.
+  --cloudtrail          Turns on AWS CloudTrail. Only available in Single
+                        Account version.
 
 Cleanup Options:
   Use these flags to choose which resources you want to turn logging off
@@ -239,7 +250,7 @@ Cleanup Options:
                         Enabler for AWS.
   --single_s3logs       Removes Amazon Bucket Log resources created by
                         Assisted Log Enabler for AWS.
-  --single_lblogs       Removes Elastic Load Balancing Log resources created by
+  --single_lblogs       Removes Amazon Load Balancer Log resources created by
                         Assisted Log Enabler for AWS.
 
 Dry Run Options:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "s3:PutBucketPublicAccessBlock",
 "s3:PutBucketLifecycleConfiguration"
 "guardduty:ListDetectors"
-"guardduty:ListInvitations"
-"guardduty:AcceptAdministratorInvitation"
 "guardduty:TagResource"
 "guardduty:CreateDetector"
 
@@ -138,8 +136,6 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 
 # For enabling GuardDuty:
 "guardduty:ListDetectors"
-"guardduty:ListInvitations"
-"guardduty:AcceptAdministratorInvitation"
 "guardduty:TagResource"
 "guardduty:CreateDetector"
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ optional arguments:
                         Enabler to store logs in. Otherwise, a new S3 bucket
                         will be created (default). Only used for Amazon VPC
                         Flow Logs, Amazon Route 53 Resolver Query Logs, and
-                        AWS CloudTrail logs.
+                        AWS CloudTrail logs. WARNING: For multi_account, this
+                        will replace the bucket policy. For single_account,
+                        this may add statements to the bucket policy.
 
 Single & Multi Account Options:
   Use these flags to choose which services you want to turn logging on for.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "s3:PutBucketAcl",
 "s3:PutBucketPublicAccessBlock",
 "s3:PutBucketLifecycleConfiguration"
+"guardduty:ListDetectors"
+"guardduty:ListInvitations"
+"guardduty:AcceptAdministratorInvitation"
+"guardduty:TagResource"
+"guardduty:CreateDetector"
 
 # For adding AWS CloudTrail logs:
 "s3:GetBucketPolicy",
@@ -130,6 +135,13 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "elasticloadbalancing:DescribeLoadBalancers",
 "elasticloadbalancing:DescribeLoadBalancerAttributes",
 "elasticloadbalancing:ModifyLoadBalancerAttributes"
+
+# For enabling GuardDuty:
+"guardduty:ListDetectors"
+"guardduty:ListInvitations"
+"guardduty:AcceptAdministratorInvitation"
+"guardduty:TagResource"
+"guardduty:CreateDetector"
 
 # For cleanup of Amazon Route 53 Resolver Query Logs created by Assisted Log Enabler for AWS:
 "route53resolver:ListResolverQueryLogConfigs",
@@ -307,6 +319,8 @@ python3 assisted_log_enabler.py --mode single_account --cloudtrail
 python3 assisted_log_enabler.py --mode single_account --s3logs
 # NEW! For Elastic Load Balancing Access Logs:
 python3 assisted_log_enabler.py --mode single_account --lblogs
+# NEW! For GuardDuty:
+python3 assisted_log_enabler.py --mode single_account --guardduty
 ```
 
 ### Step-by-Step Instructions (for running in AWS CloudShell, multi account mode)
@@ -368,6 +382,8 @@ For Amazon S3 Server Access Logs:
 python3 assisted_log_enabler.py --mode multi_account --s3logs
 # NEW! For Elastic Load Balancing Access Logs:
 python3 assisted_log_enabler.py --mode multi_account --lblogs
+# NEW! For GuardDuty:
+python3 assisted_log_enabler.py --mode multi_account --guardduty
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "s3:GetBucketAcl",
 "s3:PutBucketAcl",
 "s3:PutBucketPublicAccessBlock",
-"s3:PutBucketLifecycleConfiguration"
-"guardduty:ListDetectors"
-"guardduty:TagResource"
-"guardduty:CreateDetector"
+"s3:PutBucketLifecycleConfiguration",
+"guardduty:ListDetectors",
+"guardduty:TagResource",
+"guardduty:CreateDetector",
+"wafv2:ListWebACLs",
+"wafv2:ListLoggingConfigurations",
+"wafv2:PutLoggingConfiguration"
 
 # For adding AWS CloudTrail logs:
 "s3:GetBucketPolicy",
@@ -135,9 +138,14 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "elasticloadbalancing:ModifyLoadBalancerAttributes"
 
 # For enabling GuardDuty:
-"guardduty:ListDetectors"
-"guardduty:TagResource"
+"guardduty:ListDetectors",
+"guardduty:TagResource",
 "guardduty:CreateDetector"
+
+# For adding WAFv2 logging:
+"wafv2:ListWebACLs",
+"wafv2:ListLoggingConfigurations",
+"wafv2:PutLoggingConfiguration"
 
 # For cleanup of Amazon Route 53 Resolver Query Logs created by Assisted Log Enabler for AWS:
 "route53resolver:ListResolverQueryLogConfigs",

--- a/README.md
+++ b/README.md
@@ -202,11 +202,12 @@ usage: assisted_log_enabler.py [-h] [--mode MODE] [--bucket BUCKET]
                                [--include_accounts ACCOUNT_NUMBERS]
                                [--exclude_accounts ACCOUNT_NUMBERS] [--all]
                                [--eks] [--vpcflow] [--r53querylogs] [--s3logs]
-                               [--lblogs] [--cloudtrail]
+                               [--lblogs] [--cloudtrail] [--guardduty]
                                [--single_r53querylogs] [--single_cloudtrail]
                                [--single_vpcflow] [--single_all]
                                [--single_s3logs] [--single_lblogs]
-                               [--single_account] [--multi_account]
+                               [--single_guardduty] [--single_account]
+                               [--multi_account]
 
 Assisted Log Enabler - Find resources that are not logging, and turn them on.
 
@@ -245,6 +246,7 @@ Single & Multi Account Options:
   --lblogs              Turns on Amazon Load Balancer Logs.
   --cloudtrail          Turns on AWS CloudTrail. Only available in Single
                         Account version.
+  --guardduty           Turns on Amazon GuardDuty.
 
 Cleanup Options:
   Use these flags to choose which resources you want to turn logging off
@@ -263,6 +265,8 @@ Cleanup Options:
                         Assisted Log Enabler for AWS.
   --single_lblogs       Removes Amazon Load Balancer Log resources created by
                         Assisted Log Enabler for AWS.
+  --single_guardduty    Removes GuardDuty detectors created by Assisted Log
+                        Enabler for AWS.
 
 Dry Run Options:
   Use these flags to run Assisted Log Enabler for AWS in Dry Run mode.

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -75,8 +75,8 @@ def assisted_log_enabler():
     output_handle.setFormatter(formatter)
 
     parser = argparse.ArgumentParser(description='Assisted Log Enabler - Find resources that are not logging, and turn them on.')
-    parser.add_argument('--mode',help=' Choose the mode that you want to run Assisted Log Enabler in. Available modes: single_account, multi_account, cleanup, dryrun. WARNING: For multi_account, You must have the associated CloudFormation template deployed as a StackSet. See the README file for more details.')
-    parser.add_argument('--bucket',help=' Specify the name of a pre-existing S3 bucket that you want Assisted Log Enabler to store logs in. Otherwise, a new S3 bucket will be created (default). Only used for Amazon VPC Flow Logs, Amazon Route 53 Resolver Query Logs, and AWS CloudTrail logs. WARNING: For multi_account, this will replace the bucket policy. For single_account, this may add statements to the bucket policy.')
+    parser.add_argument('--mode', help=' Choose the mode that you want to run Assisted Log Enabler in. Available modes: single_account, multi_account, cleanup, dryrun. WARNING: For multi_account, You must have the associated CloudFormation template deployed as a StackSet. See the README file for more details.')
+    parser.add_argument('--bucket', help=' Specify the name of a pre-existing S3 bucket that you want Assisted Log Enabler to store logs in. Otherwise, a new S3 bucket will be created (default). Only used for Amazon VPC Flow Logs, Amazon Route 53 Resolver Query Logs, AWS CloudTrail logs, and Amazon GuardDuty. WARNING: This will replace the bucket policy.')
     parser.add_argument('--include_accounts', metavar='ACCOUNT_NUMBERS', help=' Specify a comma separated list of AWS account numbers to INCLUDE for multi_account mode.')
     parser.add_argument('--exclude_accounts', metavar='ACCOUNT_NUMBERS', help=' Specify a comma separated list of AWS account numbers to EXCLUDE for multi_account mode.')
 
@@ -88,7 +88,7 @@ def assisted_log_enabler():
     function_parser_group.add_argument('--s3logs', action='store_true', help=' Turns on Amazon Bucket Logs.')
     function_parser_group.add_argument('--lblogs', action='store_true', help=' Turns on Amazon Load Balancer Logs.')
     function_parser_group.add_argument('--cloudtrail', action='store_true', help=' Turns on AWS CloudTrail. Only available in Single Account version.')
-    function_parser_group.add_argument('--guardduty', action='store_true', help=' Turns on Amazon GuardDuty.')
+    function_parser_group.add_argument('--guardduty', action='store_true', help=' Turns on Amazon GuardDuty and exports findings to an S3 bucket. Will used specified bucket. WARNING: This creates a KMS Key to export findings.')
     function_parser_group.add_argument('--wafv2', action='store_true', help=' Turns on AWS WAFv2 Logs')
 
     cleanup_parser_group = parser.add_argument_group('Cleanup Options', 'Use these flags to choose which resources you want to turn logging off for.')
@@ -129,7 +129,7 @@ def assisted_log_enabler():
         elif args.cloudtrail:
             ALE_single_account.run_cloudtrail(bucket_name)
         elif args.guardduty:
-            ALE_single_account.run_guardduty()
+            ALE_single_account.run_guardduty(bucket_name)
         elif args.wafv2:
             ALE_single_account.run_wafv2_logs()
         elif args.all:
@@ -167,7 +167,7 @@ def assisted_log_enabler():
         elif args.lblogs:
             ALE_multi_account.run_lb_logs(included_accounts, excluded_accounts)
         elif args.guardduty:
-            ALE_multi_account.run_guardduty(included_accounts, excluded_accounts)
+            ALE_multi_account.run_guardduty(bucket_name, included_accounts, excluded_accounts)
         elif args.wafv2:
             ALE_multi_account.run_wafv2_logs(included_accounts, excluded_accounts)
         elif args.all:

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -77,8 +77,8 @@ def assisted_log_enabler():
     parser = argparse.ArgumentParser(description='Assisted Log Enabler - Find resources that are not logging, and turn them on.')
     parser.add_argument('--mode',help=' Choose the mode that you want to run Assisted Log Enabler in. Available modes: single_account, multi_account, cleanup, dryrun. WARNING: For multi_account, You must have the associated CloudFormation template deployed as a StackSet. See the README file for more details.')
     parser.add_argument('--bucket',help=' Specify the name of a pre-existing S3 bucket that you want Assisted Log Enabler to store logs in. Otherwise, a new S3 bucket will be created (default). Only used for Amazon VPC Flow Logs, Amazon Route 53 Resolver Query Logs, and AWS CloudTrail logs. WARNING: For multi_account, this will replace the bucket policy. For single_account, this may add statements to the bucket policy.')
-    parser.add_argument('--include_accounts',help=' Specify AWS accounts to include for multi_account mode.')
-    parser.add_argument('--exclude_accounts',help=' Specify AWS accounts to exclude for multi_account mode.')
+    parser.add_argument('--include_accounts', metavar='ACCOUNT_NUMBERS', help=' Specify a comma separated list of AWS account numbers to INCLUDE for multi_account mode.')
+    parser.add_argument('--exclude_accounts', metavar='ACCOUNT_NUMBERS', help=' Specify a comma separated list of AWS account numbers to EXCLUDE for multi_account mode.')
 
     function_parser_group = parser.add_argument_group('Single & Multi Account Options', 'Use these flags to choose which services you want to turn logging on for.')
     function_parser_group.add_argument('--all', action='store_true', help=' Turns on all of the log types within the Assisted Log Enabler for AWS.')

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -88,6 +88,7 @@ def assisted_log_enabler():
     function_parser_group.add_argument('--s3logs', action='store_true', help=' Turns on Amazon Bucket Logs.')
     function_parser_group.add_argument('--lblogs', action='store_true', help=' Turns on Amazon Load Balancer Logs.')
     function_parser_group.add_argument('--cloudtrail', action='store_true', help=' Turns on AWS CloudTrail. Only available in Single Account version.')
+    function_parser_group.add_argument('--guardduty', action='store_true', help=' Turns on Amazon GuardDuty.')
 
     cleanup_parser_group = parser.add_argument_group('Cleanup Options', 'Use these flags to choose which resources you want to turn logging off for.')
     cleanup_parser_group.add_argument('--single_r53querylogs', action='store_true', help=' Removes Amazon Route 53 Resolver Query Log resources created by Assisted Log Enabler for AWS.')
@@ -96,6 +97,7 @@ def assisted_log_enabler():
     cleanup_parser_group.add_argument('--single_all', action='store_true', help=' Turns off all of the log types within the Assisted Log Enabler for AWS.')
     cleanup_parser_group.add_argument('--single_s3logs', action='store_true', help=' Removes Amazon Bucket Log resources created by Assisted Log Enabler for AWS.')
     cleanup_parser_group.add_argument('--single_lblogs', action='store_true', help=' Removes Amazon Load Balancer Log resources created by Assisted Log Enabler for AWS.')
+    cleanup_parser_group.add_argument('--single_guardduty', action='store_true', help=' Removes GuardDuty detectors created by Assisted Log Enabler for AWS.')
 
     dryrun_parser_group = parser.add_argument_group('Dry Run Options', 'Use these flags to run Assisted Log Enabler for AWS in Dry Run mode.')
     dryrun_parser_group.add_argument('--single_account', action='store_true', help=' Runs Assisted Log Enabler for AWS in Dry Run mode for a single AWS account.')
@@ -124,6 +126,8 @@ def assisted_log_enabler():
             ALE_single_account.run_lb_logs()
         elif args.cloudtrail:
             ALE_single_account.run_cloudtrail(bucket_name)
+        elif args.guardduty:
+            ALE_single_account.run_guardduty()
         elif args.all:
             ALE_single_account.lambda_handler(event, context, bucket_name)
         else:
@@ -173,6 +177,8 @@ def assisted_log_enabler():
             ALE_cleanup_single.run_cloudtrail_cleanup()
         elif args.single_vpcflow:
             ALE_cleanup_single.run_vpcflow_cleanup()
+        elif args.single_guardduty:
+            ALE_cleanup_single.run_guardduty_cleanup()
         elif args.single_all:
             ALE_cleanup_single.lambda_handler(event, context)
         else:

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -162,6 +162,8 @@ def assisted_log_enabler():
             ALE_multi_account.run_s3_logs(included_accounts, excluded_accounts)
         elif args.lblogs:
             ALE_multi_account.run_lb_logs(included_accounts, excluded_accounts)
+        elif args.guardduty:
+            ALE_multi_account.run_guardduty(included_accounts, excluded_accounts)
         elif args.all:
             ALE_multi_account.lambda_handler(event, context, bucket_name, included_accounts, excluded_accounts)
         else:

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -89,6 +89,7 @@ def assisted_log_enabler():
     function_parser_group.add_argument('--lblogs', action='store_true', help=' Turns on Amazon Load Balancer Logs.')
     function_parser_group.add_argument('--cloudtrail', action='store_true', help=' Turns on AWS CloudTrail. Only available in Single Account version.')
     function_parser_group.add_argument('--guardduty', action='store_true', help=' Turns on Amazon GuardDuty.')
+    function_parser_group.add_argument('--wafv2', action='store_true', help=' Turns on AWS WAFv2 Logs')
 
     cleanup_parser_group = parser.add_argument_group('Cleanup Options', 'Use these flags to choose which resources you want to turn logging off for.')
     cleanup_parser_group.add_argument('--single_r53querylogs', action='store_true', help=' Removes Amazon Route 53 Resolver Query Log resources created by Assisted Log Enabler for AWS.')
@@ -97,7 +98,8 @@ def assisted_log_enabler():
     cleanup_parser_group.add_argument('--single_all', action='store_true', help=' Turns off all of the log types within the Assisted Log Enabler for AWS.')
     cleanup_parser_group.add_argument('--single_s3logs', action='store_true', help=' Removes Amazon Bucket Log resources created by Assisted Log Enabler for AWS.')
     cleanup_parser_group.add_argument('--single_lblogs', action='store_true', help=' Removes Amazon Load Balancer Log resources created by Assisted Log Enabler for AWS.')
-    cleanup_parser_group.add_argument('--single_guardduty', action='store_true', help=' Removes GuardDuty detectors created by Assisted Log Enabler for AWS.')
+    cleanup_parser_group.add_argument('--single_guardduty', action='store_true', help=' Removes Amazon GuardDuty detectors created by Assisted Log Enabler for AWS.')
+    cleanup_parser_group.add_argument('--single_wafv2', action='store_true', help=' Removes AWS WAFv2 Logging Configurations created by Assisted Log Enabler for AWS.')
 
     dryrun_parser_group = parser.add_argument_group('Dry Run Options', 'Use these flags to run Assisted Log Enabler for AWS in Dry Run mode.')
     dryrun_parser_group.add_argument('--single_account', action='store_true', help=' Runs Assisted Log Enabler for AWS in Dry Run mode for a single AWS account.')
@@ -128,6 +130,8 @@ def assisted_log_enabler():
             ALE_single_account.run_cloudtrail(bucket_name)
         elif args.guardduty:
             ALE_single_account.run_guardduty()
+        elif args.wafv2:
+            ALE_single_account.run_wafv2_logs()
         elif args.all:
             ALE_single_account.lambda_handler(event, context, bucket_name)
         else:
@@ -164,6 +168,8 @@ def assisted_log_enabler():
             ALE_multi_account.run_lb_logs(included_accounts, excluded_accounts)
         elif args.guardduty:
             ALE_multi_account.run_guardduty(included_accounts, excluded_accounts)
+        elif args.wafv2:
+            ALE_multi_account.run_wafv2_logs(included_accounts, excluded_accounts)
         elif args.all:
             ALE_multi_account.lambda_handler(event, context, bucket_name, included_accounts, excluded_accounts)
         else:
@@ -181,6 +187,8 @@ def assisted_log_enabler():
             ALE_cleanup_single.run_vpcflow_cleanup()
         elif args.single_guardduty:
             ALE_cleanup_single.run_guardduty_cleanup()
+        elif args.single_wafv2:
+            ALE_cleanup_single.run_wafv2_cleanup()
         elif args.single_all:
             ALE_cleanup_single.lambda_handler(event, context)
         else:

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -75,7 +75,8 @@ def assisted_log_enabler():
 
     parser = argparse.ArgumentParser(description='Assisted Log Enabler - Find resources that are not logging, and turn them on.')
     parser.add_argument('--mode',help=' Choose the mode that you want to run Assisted Log Enabler in. Available modes: single_account, multi_account, cleanup, dryrun. WARNING: For multi_account, You must have the associated CloudFormation template deployed as a StackSet. See the README file for more details.')
-    
+    parser.add_argument('--bucket',help=' Specify an S3 bucket name that you want Assisted Log Enabler to store logs in. Otherwise, a new S3 bucket will be created (default). Only used for Amazon VPC Flow Logs, Amazon Route 53 Resolver Query Logs, and AWS CloudTrail logs. WARNING: For multi_account, this will replace the bucket policy. For single_account, this may add statements to the bucket policy.')
+
     function_parser_group = parser.add_argument_group('Single & Multi Account Options', 'Use these flags to choose which services you want to turn logging on for.')
     function_parser_group.add_argument('--all', action='store_true', help=' Turns on all of the log types within the Assisted Log Enabler for AWS.')
     function_parser_group.add_argument('--eks', action='store_true', help=' Turns on Amazon EKS audit & authenticator logs.')
@@ -102,36 +103,41 @@ def assisted_log_enabler():
 
     event = 'event'
     context = 'context'
+    bucket_name = 'default'
     if args.mode == 'single_account':
+        if args.bucket:
+            bucket_name = args.bucket
         if args.eks:
             ALE_single_account.run_eks()
         elif args.vpcflow:
-            ALE_single_account.run_vpc_flow_logs()
+            ALE_single_account.run_vpc_flow_logs(bucket_name)
         elif args.r53querylogs:
-            ALE_single_account.run_r53_query_logs()
+            ALE_single_account.run_r53_query_logs(bucket_name)
         elif args.s3logs:
             ALE_single_account.run_s3_logs()
         elif args.lblogs:
             ALE_single_account.run_lb_logs()
         elif args.cloudtrail:
-            ALE_single_account.run_cloudtrail()
+            ALE_single_account.run_cloudtrail(bucket_name)
         elif args.all:
-            ALE_single_account.lambda_handler(event, context)
+            ALE_single_account.lambda_handler(event, context, bucket_name)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'multi_account':
+        if args.bucket:
+            bucket_name = args.bucket
         if args.eks:
             ALE_multi_account.run_eks()
         elif args.vpcflow:
-            ALE_multi_account.run_vpc_flow_logs()
+            ALE_multi_account.run_vpc_flow_logs(bucket_name)
         elif args.r53querylogs:
-            ALE_multi_account.run_r53_query_logs()
+            ALE_multi_account.run_r53_query_logs(bucket_name)
         elif args.s3logs:
             ALE_multi_account.run_s3_logs()
         elif args.lblogs:
             ALE_multi_account.run_lb_logs()
         elif args.all:
-            ALE_multi_account.lambda_handler(event, context)
+            ALE_multi_account.lambda_handler(event, context, bucket_name)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'cleanup':

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -50,6 +50,7 @@ Resources:
               - route53resolver:ListResolverQueryLogConfigAssociations
               - route53resolver:CreateResolverQueryLogConfig
               - route53resolver:AssociateResolverQueryLogConfig
+              - route53resolver:TagResource
               - s3:PutBucketLogging
               - s3:GetBucketLogging
               - s3:ListBucket
@@ -69,6 +70,7 @@ Resources:
               - elasticloadbalancing:DescribeLoadBalancerAttributes
               - elasticloadbalancing:ModifyLoadBalancerAttributes
               - eks:ListClusters
+              - ec2:CreateTags
             Resource: '*'
             Condition:
               StringEquals:

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -72,8 +72,6 @@ Resources:
               - eks:ListClusters
               - ec2:CreateTags
               - guardduty:ListDetectors
-              - guardduty:ListInvitations
-              - guardduty:AcceptAdministratorInvitation
               - guardduty:TagResource
               - guardduty:CreateDetector
             Resource: '*'

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -60,6 +60,7 @@ Resources:
               - s3:PutBucketAcl
               - s3:PutBucketPublicAccessBlock
               - s3:PutBucketLifecycleConfiguration
+              - s3:GetObject
               - elb:DescribeLoadBalancers
               - elb:DescribeLoadBalancerAttributes
               - elb:ModifyLoadBalancerAttributes
@@ -74,6 +75,9 @@ Resources:
               - guardduty:ListDetectors
               - guardduty:TagResource
               - guardduty:CreateDetector
+              - guardduty:ListPublishingDestinations
+              - guardduty:CreatePublishingDestination
+              - guardduty:DescribePublishingDestination
               - wafv2:ListWebACLs
               - wafv2:ListLoggingConfigurations
               - wafv2:PutLoggingConfiguration

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -74,6 +74,9 @@ Resources:
               - guardduty:ListDetectors
               - guardduty:TagResource
               - guardduty:CreateDetector
+              - wafv2:ListWebACLs
+              - wafv2:ListLoggingConfigurations
+              - wafv2:PutLoggingConfiguration
             Resource: '*'
             Condition:
               StringEquals:

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -71,6 +71,11 @@ Resources:
               - elasticloadbalancing:ModifyLoadBalancerAttributes
               - eks:ListClusters
               - ec2:CreateTags
+              - guardduty:ListDetectors
+              - guardduty:ListInvitations
+              - guardduty:AcceptAdministratorInvitation
+              - guardduty:TagResource
+              - guardduty:CreateDetector
             Resource: '*'
             Condition:
               StringEquals:

--- a/subfunctions/ALE_cleanup_single.py
+++ b/subfunctions/ALE_cleanup_single.py
@@ -301,6 +301,46 @@ def lb_cleanup():
         except Exception as exception_handle:
             logging.error(exception_handle)
 
+
+def guardduty_cleanup():
+    """"Function to cleanup GuardDuty detectors"""
+    logging.info("Cleaning up GuardDuty detectors created by Assisted Log Enabler for AWS.")
+    for aws_region in region_list:
+        detector_list = []
+        removal_list = []
+        guardduty = boto3.client('guardduty', region_name=aws_region)
+        try:
+            logging.info("---- LINE BREAK BETWEEN REGIONS ----")
+            logging.info("Cleaning up GuardDuty detectors created by Assisted Log Enabler for AWS in region " + aws_region + ".")
+            logging.info("ListDetectors API Call")
+            detector_list = guardduty.list_detectors()["DetectorIds"]
+            if detector_list != []:
+                logging.info("GuardDuty detectors found: ")
+                print(detector_list)
+                logging.info("Checking tags for GuardDuty detectors created by Assisted Log Enabler.")
+                for detector_id in detector_list:
+                    logging.info("GetDetector API Call")
+                    detector = guardduty.get_detector(DetectorId=detector_id)
+                    for tag in detector["Tags"]:
+                        if tag == "workflow":
+                            if detector["Tags"]["workflow"] == "assisted-log-enabler":
+                                removal_list.append(detector_id)
+                if removal_list != []:
+                    logging.info("GuardDuty detectors created by Assisted Log Enabler to be deleted: ")
+                    print(removal_list)
+                    for detector_id in removal_list:
+                        logging.info("Removing GuardDuty detector " + detector_id)
+                        logging.info("DeleteDetector API Call")
+                        guardduty.delete_detector(DetectorId=detector_id)
+                else:
+                    logging.info("There are no GuardDuty detectors created by Assisted Log Enabler in region " +  aws_region + ".")
+            else:
+                logging.info("No GuardDuty detectors enabled in region " + aws_region + ".")
+
+        except Exception as exception_handle:
+            logging.error(exception_handle)
+
+
 def run_vpcflow_cleanup():
     """Function to run the vpcflow_cleanup function"""
     vpcflow_cleanup()
@@ -328,6 +368,11 @@ def run_lb_cleanup():
     lb_cleanup()
     logging.info("This is the end of the script. Please feel free to validate that logging resources have been cleaned up.")
 
+def run_guardduty_cleanup():
+    """Function to run the guardduty_cleanup function"""
+    guardduty_cleanup()
+    logging.info("This is the end of the script. Please feel free to validate that logging resources have been cleaned up.")
+
 def lambda_handler(event, context):
     """Function that runs all of the previously defined functions"""
     r53_cleanup()
@@ -335,6 +380,7 @@ def lambda_handler(event, context):
     cloudtrail_cleanup()
     s3_cleanup()
     lb_cleanup()
+    guardduty_cleanup()
     logging.info("This is the end of the script. Please feel free to validate that logging resources have been cleaned up.")
 
 

--- a/subfunctions/ALE_dryrun_multi.py
+++ b/subfunctions/ALE_dryrun_multi.py
@@ -307,6 +307,8 @@ def dryrun_lb_logs(region_list, account_number, OrgAccountIdList):
 
 def dryrun_check_guardduty(region_list, OrgAccountIdList):
     """Function to check if GuardDuty is enabled"""
+    logging.info("Creating KMS key for GuardDuty to export findings.")
+    logging.info("Creating /guardduty folder in S3 Bucket")
     for org_account in OrgAccountIdList:
         for aws_region in region_list:
             logging.info("Checking for GuardDuty detectors in the account "  + org_account + " in region " + aws_region + ".")
@@ -330,8 +332,28 @@ def dryrun_check_guardduty(region_list, OrgAccountIdList):
                 detectors = guardduty_ma.list_detectors()
                 if detectors["DetectorIds"] == []:
                     logging.info("GuardDuty is not enabled in the account " + org_account + ", region " + aws_region)
+                    logging.info("Enabling GuardDuty")
+                    logging.info("Exporting GuardDuty findings to an S3 bucket.")
+                    logging.info("Setting S3 Bucket as publishing destination for GuardDuty detector.")
                 else:
                     logging.info("GuardDuty is already enabled in the account " + org_account + ", region " + aws_region)
+                    detector_id = detectors["DetectorIds"][0]
+                    logging.info("Checking if GuardDuty detector publishes findings to S3.")
+                    logging.info("ListPublishingDestinations API Call")
+                    gd_destinations = guardduty_ma.list_publishing_destinations(DetectorId=detector_id)["Destinations"]
+                    if gd_destinations == []:
+                        logging.info("Detector does not publish findings to a destination. Setting S3 Bucket as publishing destination for GuardDuty detector.")
+                    else:
+                        for dest in gd_destinations:
+                            if dest["DestinationType"] == "S3":
+                                dest_id = dest["DestinationId"]
+                                logging.info("DescribePublishingDestination API Call")
+                                dest_info = guardduty_ma.describe_publishing_destination(
+                                    DetectorId=detector_id,
+                                    DestinationId=dest_id
+                                )
+                                dest_s3_arn = dest_info["DestinationProperties"]["DestinationArn"]
+                                logging.info("Detector already publishes findings to S3 bucket " + dest_s3_arn.split(":")[-1])
             except Exception as exception_handle:
                 logging.error(exception_handle)
 

--- a/subfunctions/ALE_dryrun_single.py
+++ b/subfunctions/ALE_dryrun_single.py
@@ -205,6 +205,21 @@ def dryrun_lb_logs(region_list, account_number):
         except Exception as exception_handle:
             logging.error(exception_handle)
 
+def dryrun_check_guardduty(region_list, account_number):
+    """Function to check if GuardDuty is enabled"""
+    for aws_region in region_list:
+        guardduty = boto3.client('guardduty', region_name=aws_region)
+        logging.info("Checking for GuardDuty detector in the account " + account_number + ", region " + aws_region)
+        try:
+            logging.info("ListDetectors API Call")
+            detectors = guardduty.list_detectors()
+            if detectors["DetectorIds"] == []:
+                logging.info("GuardDuty is not enabled in the account" + account_number + ", region " + aws_region)
+            else:
+                logging.info("GuardDuty is already enabled in the account " + account_number + ", region " + aws_region)
+        except Exception as exception_handle:
+            logging.error(exception_handle)
+
 def lambda_handler(event, context):
     """Function that runs all of the previously defined functions"""
     dryrun_flow_log_activator(region_list, account_number)
@@ -213,6 +228,7 @@ def lambda_handler(event, context):
     dryrun_route_53_query_logs(region_list, account_number)
     dryrun_s3_logs(region_list, account_number)
     dryrun_lb_logs(region_list, account_number)
+    dryrun_check_guardduty(region_list, account_number)
     logging.info("This is the end of the script. Please check the logs for the resources that would be turned on outside of the Dry Run option.")
 
 

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -30,8 +30,7 @@ organizations = boto3.client('organizations')
 region = os.environ['AWS_REGION']
 
 
-#region_list = ['af-south-1', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'eu-south-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
-region_list = ['us-east-1'] # >>> TESTING ONLY <<<<
+region_list = ['af-south-1', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'eu-south-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
 
 # 0. Define random string for S3 Bucket Name
 def random_string_generator():

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -30,7 +30,8 @@ organizations = boto3.client('organizations')
 region = os.environ['AWS_REGION']
 
 
-region_list = ['af-south-1', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'eu-south-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
+#region_list = ['af-south-1', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'eu-south-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
+region_list = ['us-east-1'] # >>> TESTING ONLY <<<<
 
 # 0. Define random string for S3 Bucket Name
 def random_string_generator():
@@ -146,273 +147,437 @@ def update_custom_bucket_policy(bucket_name, account_number):
 
 
 # 4. Find VPCs and turn flow logs on if not on already.
-def flow_log_activator(OrgAccountIdList, region_list, bucket_name):
+def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts):
     """Function to define the list of VPCs without logging turned on"""
     logging.info("Creating a list of VPCs without Flow Logs on.")
     for org_account in OrgAccountIdList:
-        for aws_region in region_list:
-            sts = boto3.client('sts')
-            RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
-            logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
-            assisted_log_enabler_sts = sts.assume_role(
-                RoleArn=RoleArn,
-                RoleSessionName='assisted-log-enabler-activation',
-                DurationSeconds=3600,
-            )
-            ec2_ma = boto3.client(
-            'ec2',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            logging.info("Creating a list of VPCs without Flow Logs on in region " + aws_region + ".")
-            try:
-                VPCList: list = []
-                FlowLogList: list = []
-                logging.info("DescribeVpcs API Call")
-                vpcs = ec2_ma.describe_vpcs()
-                for vpc_id in vpcs["Vpcs"]:
-                    VPCList.append(vpc_id["VpcId"])
-                logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + ":")
-                print(VPCList)
-                vpcflowloglist = ec2_ma.describe_flow_logs()
-                logging.info("DescribeFlowLogs API Call")
-                for resource_id in vpcflowloglist["FlowLogs"]:
-                    FlowLogList.append(resource_id["ResourceId"])
-                working_list = (list(set(VPCList) - set(FlowLogList)))
-                logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + " WITHOUT VPC Flow Logs:")
-                print(working_list)
-                for no_logs in working_list:
-                    logging.info(no_logs + " does not have VPC Flow logging on. It will be turned on within this function.")
-                logging.info("Activating logs for VPCs that do not have them turned on.")
-                logging.info("If all VPCs have Flow Logs turned on, you will get an MissingParameter error. That is normal.")
-                logging.info("CreateFlowLogs API Call")
-                flow_log_on =  ec2_ma.create_flow_logs(
-                    ResourceIds=working_list,
-                    ResourceType='VPC',
-                    TrafficType='ALL',
-                    LogDestinationType='s3',
-                    LogDestination='arn:aws:s3:::' + bucket_name + '/vpcflowlogs',
-                    LogFormat='${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status} ${vpc-id} ${type} ${tcp-flags} ${subnet-id} ${sublocation-type} ${sublocation-id} ${region} ${pkt-srcaddr} ${pkt-dstaddr} ${instance-id} ${az-id} ${pkt-src-aws-service} ${pkt-dst-aws-service} ${flow-direction} ${traffic-path}',
-                    TagSpecifications=[
-                        {
-                            'ResourceType': 'vpc-flow-log',
-                            'Tags': [
-                                {
-                                    'Key': 'workflow',
-                                    'Value': 'assisted-log-enabler'
-                                },
-                            ]
-                        }
-                    ]
+        if excluded_accounts != 'none' and org_account in excluded_accounts:
+            continue
+        elif included_accounts == 'all' or org_account in included_accounts:
+            for aws_region in region_list:
+                sts = boto3.client('sts')
+                RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
+                logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
+                assisted_log_enabler_sts = sts.assume_role(
+                    RoleArn=RoleArn,
+                    RoleSessionName='assisted-log-enabler-activation',
+                    DurationSeconds=3600,
                 )
-                logging.info("VPC Flow Logs are turned on for account " + org_account + ".")
-            except Exception as exception_handle:
-                logging.error(exception_handle)
+                ec2_ma = boto3.client(
+                'ec2',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                logging.info("Creating a list of VPCs without Flow Logs on in region " + aws_region + ".")
+                try:
+                    VPCList: list = []
+                    FlowLogList: list = []
+                    logging.info("DescribeVpcs API Call")
+                    vpcs = ec2_ma.describe_vpcs()
+                    for vpc_id in vpcs["Vpcs"]:
+                        VPCList.append(vpc_id["VpcId"])
+                    logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + ":")
+                    print(VPCList)
+                    vpcflowloglist = ec2_ma.describe_flow_logs()
+                    logging.info("DescribeFlowLogs API Call")
+                    for resource_id in vpcflowloglist["FlowLogs"]:
+                        FlowLogList.append(resource_id["ResourceId"])
+                    working_list = (list(set(VPCList) - set(FlowLogList)))
+                    logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + " WITHOUT VPC Flow Logs:")
+                    print(working_list)
+                    for no_logs in working_list:
+                        logging.info(no_logs + " does not have VPC Flow logging on. It will be turned on within this function.")
+                    logging.info("Activating logs for VPCs that do not have them turned on.")
+                    logging.info("If all VPCs have Flow Logs turned on, you will get an MissingParameter error. That is normal.")
+                    logging.info("CreateFlowLogs API Call")
+                    flow_log_on =  ec2_ma.create_flow_logs(
+                        ResourceIds=working_list,
+                        ResourceType='VPC',
+                        TrafficType='ALL',
+                        LogDestinationType='s3',
+                        LogDestination='arn:aws:s3:::' + bucket_name + '/vpcflowlogs',
+                        LogFormat='${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status} ${vpc-id} ${type} ${tcp-flags} ${subnet-id} ${sublocation-type} ${sublocation-id} ${region} ${pkt-srcaddr} ${pkt-dstaddr} ${instance-id} ${az-id} ${pkt-src-aws-service} ${pkt-dst-aws-service} ${flow-direction} ${traffic-path}',
+                        TagSpecifications=[
+                            {
+                                'ResourceType': 'vpc-flow-log',
+                                'Tags': [
+                                    {
+                                        'Key': 'workflow',
+                                        'Value': 'assisted-log-enabler'
+                                    },
+                                ]
+                            }
+                        ]
+                    )
+                    logging.info("VPC Flow Logs are turned on for account " + org_account + ".")
+                except Exception as exception_handle:
+                    logging.error(exception_handle)
 
 
 # 5. Turn on EKS audit and authenticator logs.
-def eks_logging(region_list, OrgAccountIdList):
+def eks_logging(region_list, OrgAccountIdList, included_accounts, excluded_accounts):
     """Function to turn on logging for EKS Clusters"""
     for org_account in OrgAccountIdList:
-        for aws_region in region_list:
-            logging.info("Turning on audit and authenticator logging for EKS clusters in AWS account " + org_account + ", in region " + aws_region + ".")
-            sts = boto3.client('sts')
-            RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
-            logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
-            assisted_log_enabler_sts = sts.assume_role(
-                RoleArn=RoleArn,
-                RoleSessionName='assisted-log-enabler-activation',
-                DurationSeconds=3600,
-            )
-            eks_ma = boto3.client(
-            'eks',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            try:
-                logging.info("ListClusters API Call")
-                eks_clusters = eks_ma.list_clusters()
-                eks_cluster_list = eks_clusters ['clusters']
-                logging.info("EKS Clusters found in " + aws_region + ":")
-                print(eks_cluster_list)
-                for cluster in eks_cluster_list:
-                    logging.info("UpdateClusterConfig API Call")
-                    eks_activate = eks_ma.update_cluster_config(
-                        name=cluster,
-                        logging={
-                            'clusterLogging': [
-                                {
-                                    'types': [
-                                        'audit',
-                                    ],
-                                    'enabled': True
-                                },
-                                {
-                                    'types': [
-                                        'authenticator',
-                                    ],
-                                    'enabled': True
-                                },
-                            ]
-                        }
-                    )
-                    if eks_activate['update']['status'] == 'InProgress':
-                        logging.info(cluster + " EKS Cluster is currently updating. Status: InProgress")
-                    elif eks_activate['update']['status'] == 'Failed':
-                        logging.info(cluster + " EKS Cluster failed to turn on logs. Please check if you have permissions to update the logging configuration of EKS. Status: Failed")
-                    elif eks_activate['update']['status'] == 'Cancelled':
-                        logging.info(cluster + " EKS Cluster log update was cancelled. Status: Cancelled.")
-                    else:
-                        logging.info(cluster + " EKS Cluster has audit and authenticator logs turned on.")
-            except Exception as exception_handle:
-                logging.error(exception_handle)
+        if excluded_accounts != 'none' and org_account in excluded_accounts:
+            continue
+        elif included_accounts == 'all' or org_account in included_accounts:
+            for aws_region in region_list:
+                logging.info("Turning on audit and authenticator logging for EKS clusters in AWS account " + org_account + ", in region " + aws_region + ".")
+                sts = boto3.client('sts')
+                RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
+                logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
+                assisted_log_enabler_sts = sts.assume_role(
+                    RoleArn=RoleArn,
+                    RoleSessionName='assisted-log-enabler-activation',
+                    DurationSeconds=3600,
+                )
+                eks_ma = boto3.client(
+                'eks',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                try:
+                    logging.info("ListClusters API Call")
+                    eks_clusters = eks_ma.list_clusters()
+                    eks_cluster_list = eks_clusters ['clusters']
+                    logging.info("EKS Clusters found in " + aws_region + ":")
+                    print(eks_cluster_list)
+                    for cluster in eks_cluster_list:
+                        logging.info("UpdateClusterConfig API Call")
+                        eks_activate = eks_ma.update_cluster_config(
+                            name=cluster,
+                            logging={
+                                'clusterLogging': [
+                                    {
+                                        'types': [
+                                            'audit',
+                                        ],
+                                        'enabled': True
+                                    },
+                                    {
+                                        'types': [
+                                            'authenticator',
+                                        ],
+                                        'enabled': True
+                                    },
+                                ]
+                            }
+                        )
+                        if eks_activate['update']['status'] == 'InProgress':
+                            logging.info(cluster + " EKS Cluster is currently updating. Status: InProgress")
+                        elif eks_activate['update']['status'] == 'Failed':
+                            logging.info(cluster + " EKS Cluster failed to turn on logs. Please check if you have permissions to update the logging configuration of EKS. Status: Failed")
+                        elif eks_activate['update']['status'] == 'Cancelled':
+                            logging.info(cluster + " EKS Cluster log update was cancelled. Status: Cancelled.")
+                        else:
+                            logging.info(cluster + " EKS Cluster has audit and authenticator logs turned on.")
+                except Exception as exception_handle:
+                    logging.error(exception_handle)
 
 
 # 6. Turn on Route 53 Query Logging.
-def route_53_query_logs(region_list, OrgAccountIdList, bucket_name):
+def route_53_query_logs(region_list, OrgAccountIdList, bucket_name, included_accounts, excluded_accounts):
     """Function to turn on Route 53 Query Logs for VPCs"""
     for org_account in OrgAccountIdList:
-        for aws_region in region_list:
-            logging.info("Turning on Route 53 Query Logging on in AWS Account " + org_account + " VPCs, in region " + aws_region + ".")
-            sts = boto3.client('sts')
-            RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
-            logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
-            assisted_log_enabler_sts = sts.assume_role(
-                RoleArn=RoleArn,
-                RoleSessionName='assisted-log-enabler-activation',
-                DurationSeconds=3600,
-            )
-            ec2_ma = boto3.client(
-            'ec2',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            route53resolver_ma = boto3.client(
-            'route53resolver',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            try:
-                VPCList: list = []
-                QueryLogList: list = []
-                logging.info("DescribeVpcs API Call")
-                vpcs = ec2_ma.describe_vpcs()
-                for vpc_id in vpcs["Vpcs"]:
-                    VPCList.append(vpc_id["VpcId"])
-                logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + ":")
-                print(VPCList)
-                logging.info("ListResolverQueryLogConfigAssociations API Call")
-                query_log_details = route53resolver_ma.list_resolver_query_log_config_associations()
-                for query_log_vpc_id in query_log_details['ResolverQueryLogConfigAssociations']:
-                    QueryLogList.append(query_log_vpc_id['ResourceId'])
-                r53_working_list = (list(set(VPCList) - set(QueryLogList)))
-                logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + " WITHOUT Route 53 Query Logs:")
-                print(r53_working_list)
-                for no_query_logs in r53_working_list:
-                    logging.info(no_query_logs + " does not have Route 53 Query logging on. It will be turned on within this function.")
-                logging.info("Activating logs for VPCs that do not have Route 53 Query logging turned on.")
-                logging.info("CreateResolverQueryLogConfig API Call")
-                create_query_log = route53resolver_ma.create_resolver_query_log_config(
-                    Name='Assisted_Log_Enabler_Query_Logs_' + aws_region,
-                    DestinationArn='arn:aws:s3:::' + bucket_name + '/r53querylogs',
-                    CreatorRequestId=timestamp_date_string,
-                    Tags=[
-                        {
-                            'Key': 'Workflow',
-                            'Value': 'assisted-log-enabler'
-                        },
-                    ]
+        if excluded_accounts != 'none' and org_account in excluded_accounts:
+            continue
+        elif included_accounts == 'all' or org_account in included_accounts:
+            for aws_region in region_list:
+                logging.info("Turning on Route 53 Query Logging on in AWS Account " + org_account + " VPCs, in region " + aws_region + ".")
+                sts = boto3.client('sts')
+                RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
+                logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
+                assisted_log_enabler_sts = sts.assume_role(
+                    RoleArn=RoleArn,
+                    RoleSessionName='assisted-log-enabler-activation',
+                    DurationSeconds=3600,
                 )
-                r53_query_log_id = create_query_log['ResolverQueryLogConfig']['Id']
-                logging.info("Route 53 Query Logging Created. Resource ID:" + r53_query_log_id)
-                for vpc in r53_working_list:
-                    logging.info("Associating " + vpc + " with the created Route 53 Query Logging.")
-                    logging.info("AssocateResolverQueryLogConfig")
-                    activate_r5_logs = route53resolver_ma.associate_resolver_query_log_config(
-                        ResolverQueryLogConfigId=r53_query_log_id,
-                        ResourceId=vpc
+                ec2_ma = boto3.client(
+                'ec2',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                route53resolver_ma = boto3.client(
+                'route53resolver',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                try:
+                    VPCList: list = []
+                    QueryLogList: list = []
+                    logging.info("DescribeVpcs API Call")
+                    vpcs = ec2_ma.describe_vpcs()
+                    for vpc_id in vpcs["Vpcs"]:
+                        VPCList.append(vpc_id["VpcId"])
+                    logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + ":")
+                    print(VPCList)
+                    logging.info("ListResolverQueryLogConfigAssociations API Call")
+                    query_log_details = route53resolver_ma.list_resolver_query_log_config_associations()
+                    for query_log_vpc_id in query_log_details['ResolverQueryLogConfigAssociations']:
+                        QueryLogList.append(query_log_vpc_id['ResourceId'])
+                    r53_working_list = (list(set(VPCList) - set(QueryLogList)))
+                    logging.info("List of VPCs found within account " + org_account + ", region " + aws_region + " WITHOUT Route 53 Query Logs:")
+                    print(r53_working_list)
+                    for no_query_logs in r53_working_list:
+                        logging.info(no_query_logs + " does not have Route 53 Query logging on. It will be turned on within this function.")
+                    logging.info("Activating logs for VPCs that do not have Route 53 Query logging turned on.")
+                    logging.info("CreateResolverQueryLogConfig API Call")
+                    create_query_log = route53resolver_ma.create_resolver_query_log_config(
+                        Name='Assisted_Log_Enabler_Query_Logs_' + aws_region,
+                        DestinationArn='arn:aws:s3:::' + bucket_name + '/r53querylogs',
+                        CreatorRequestId=timestamp_date_string,
+                        Tags=[
+                            {
+                                'Key': 'Workflow',
+                                'Value': 'assisted-log-enabler'
+                            },
+                        ]
                     )
-            except Exception as exception_handle:
-                logging.error(exception_handle)
+                    r53_query_log_id = create_query_log['ResolverQueryLogConfig']['Id']
+                    logging.info("Route 53 Query Logging Created. Resource ID:" + r53_query_log_id)
+                    for vpc in r53_working_list:
+                        logging.info("Associating " + vpc + " with the created Route 53 Query Logging.")
+                        logging.info("AssocateResolverQueryLogConfig")
+                        activate_r5_logs = route53resolver_ma.associate_resolver_query_log_config(
+                            ResolverQueryLogConfigId=r53_query_log_id,
+                            ResourceId=vpc
+                        )
+                except Exception as exception_handle:
+                    logging.error(exception_handle)
 
 
 # 7. Turn on S3 Logging.
-def s3_logs(region_list, account_number, OrgAccountIdList, unique_end):
+def s3_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts):
     """Function to turn on Bucket Logs for Buckets"""
     for org_account in OrgAccountIdList:
-        for aws_region in region_list:
-            logging.info("Turning on Bucket Logging on in AWS Account " + org_account + " Buckets, in region " + aws_region + ".")
-            sts = boto3.client('sts')
-            RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
-            logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
-            assisted_log_enabler_sts = sts.assume_role(
-                RoleArn=RoleArn,
-                RoleSessionName='assisted-log-enabler-activation',
-                DurationSeconds=3600,
-            )
-            s3_ma = boto3.client(
-            's3',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            try:
-                S3List: list = []
-                S3LogList: list = []
-                logging.info("ListBuckets API Call")
-                buckets = s3_ma.list_buckets()
-                for bucket in buckets['Buckets']:
-                    s3region=s3_ma.get_bucket_location(Bucket=bucket["Name"])['LocationConstraint']
-                    if s3region == aws_region:
-                        S3List.append(bucket["Name"])
-                    elif s3region is None and aws_region == 'us-east-1':
-                        S3List.append(bucket["Name"])
-                if S3List != []:
-                    logging.info("List of Buckets found within account " + org_account + ", region " + aws_region + ":")
-                    print(S3List)
-                    logging.info("Parsed out buckets created by Assisted Log Enabler for AWS in " + aws_region)
-                    logging.info("Checking remaining buckets to see if logs were enabled by Assisted Log Enabler for AWS in " + aws_region)
-                    logging.info("GetBucketLogging API Call")
-                    for bucket in S3List:
-                        if 'aws-s3-log-collection-' + org_account + '-' + aws_region not in str(bucket):
-                            s3temp=s3_ma.get_bucket_logging(Bucket=bucket)
-                            if 'TargetBucket' not in str(s3temp):
-                                S3LogList.append(bucket)
-                    if S3LogList != []:
-                        logging.info("List of Buckets found within account " + org_account + ", region " + aws_region + " WITHOUT S3 Bucket Logs:")
-                        print(S3LogList)
-                        for bucket in S3LogList:
-                            logging.info(bucket + " does not have S3 BUCKET logging on. It will be turned on within this function.")
-                        logging.info("Creating S3 Logging Bucket")
-                        """Function to create the bucket for storing logs"""
-                        account_number = sts.get_caller_identity()["Account"]
+        if excluded_accounts != 'none' and org_account in excluded_accounts:
+            continue
+        elif included_accounts == 'all' or org_account in included_accounts:
+            for aws_region in region_list:
+                logging.info("Turning on Bucket Logging on in AWS Account " + org_account + " Buckets, in region " + aws_region + ".")
+                sts = boto3.client('sts')
+                RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
+                logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
+                assisted_log_enabler_sts = sts.assume_role(
+                    RoleArn=RoleArn,
+                    RoleSessionName='assisted-log-enabler-activation',
+                    DurationSeconds=3600,
+                )
+                s3_ma = boto3.client(
+                's3',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                try:
+                    S3List: list = []
+                    S3LogList: list = []
+                    logging.info("ListBuckets API Call")
+                    buckets = s3_ma.list_buckets()
+                    for bucket in buckets['Buckets']:
+                        s3region=s3_ma.get_bucket_location(Bucket=bucket["Name"])['LocationConstraint']
+                        if s3region == aws_region:
+                            S3List.append(bucket["Name"])
+                        elif s3region is None and aws_region == 'us-east-1':
+                            S3List.append(bucket["Name"])
+                    if S3List != []:
+                        logging.info("List of Buckets found within account " + org_account + ", region " + aws_region + ":")
+                        print(S3List)
+                        logging.info("Parsed out buckets created by Assisted Log Enabler for AWS in " + aws_region)
+                        logging.info("Checking remaining buckets to see if logs were enabled by Assisted Log Enabler for AWS in " + aws_region)
+                        logging.info("GetBucketLogging API Call")
+                        for bucket in S3List:
+                            if 'aws-s3-log-collection-' + org_account + '-' + aws_region not in str(bucket):
+                                s3temp=s3_ma.get_bucket_logging(Bucket=bucket)
+                                if 'TargetBucket' not in str(s3temp):
+                                    S3LogList.append(bucket)
+                        if S3LogList != []:
+                            logging.info("List of Buckets found within account " + org_account + ", region " + aws_region + " WITHOUT S3 Bucket Logs:")
+                            print(S3LogList)
+                            for bucket in S3LogList:
+                                logging.info(bucket + " does not have S3 BUCKET logging on. It will be turned on within this function.")
+                            logging.info("Creating S3 Logging Bucket")
+                            """Function to create the bucket for storing logs"""
+                            account_number = sts.get_caller_identity()["Account"]
+                            logging.info("Creating bucket in %s" % org_account)
+                            logging.info("CreateBucket API Call")
+                            if aws_region == 'us-east-1':
+                                logging_bucket_dict = s3_ma.create_bucket(
+                                    Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end
+                                )
+                            else:
+                                logging_bucket_dict = s3_ma.create_bucket(
+                                    Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                                    CreateBucketConfiguration={
+                                        'LocationConstraint': aws_region
+                                    }
+                                )
+                            logging.info("Bucket " + "aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end + " Created.")
+                            logging.info("Setting lifecycle policy.")
+                            logging.info("PutBucketLifecycleConfiguration API Call")
+                            lifecycle_policy = s3_ma.put_bucket_lifecycle_configuration(
+                                Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                                LifecycleConfiguration={
+                                    'Rules': [
+                                        {
+                                            'Expiration': {
+                                                'Days': 365
+                                            },
+                                            'Status': 'Enabled',
+                                            'Prefix': '',
+                                            'ID': 'LogStorage',
+                                            'Transitions': [
+                                                {
+                                                    'Days': 90,
+                                                    'StorageClass': 'INTELLIGENT_TIERING'
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            )
+                            logging.info("Lifecycle Policy successfully set.")
+                            logging.info("Setting the S3 bucket Public Access to Blocked")
+                            logging.info("PutPublicAccessBlock API Call")
+                            bucket_private = s3_ma.put_public_access_block(
+                                Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                                PublicAccessBlockConfiguration={
+                                    'BlockPublicAcls': True,
+                                    'IgnorePublicAcls': True,
+                                    'BlockPublicPolicy': True,
+                                    'RestrictPublicBuckets': True
+                                },
+                            )
+                            logging.info("GetBucketAcl API Call")
+                            id=s3_ma.get_bucket_acl(Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end)['Owner']['ID']
+                            logging.info("PutBucketAcl API Call")
+                            s3_ma.put_bucket_acl(Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,GrantReadACP='uri=http://acs.amazonaws.com/groups/s3/LogDelivery',GrantWrite='uri=http://acs.amazonaws.com/groups/s3/LogDelivery',GrantFullControl='id=' + id)
+                            for bucket in S3LogList:
+                                logging.info("Activating logs for S3 Bucket " + bucket)
+                                logging.info("PutBucketLogging API Call")
+                                create_s3_log = s3_ma.put_bucket_logging(
+                                    Bucket=bucket,
+                                    BucketLoggingStatus={
+                                        'LoggingEnabled': {
+                                            'TargetBucket': 'aws-s3-log-collection-' + org_account + '-' + aws_region + '-' + unique_end,
+                                            'TargetGrants': [
+                                                {
+                                                    'Permission': 'FULL_CONTROL',
+                                                    'Grantee': {
+                                                        'Type': 'Group',
+                                                        'URI': 'http://acs.amazonaws.com/groups/s3/LogDelivery'
+                                                    },
+                                                },
+                                            ],
+                                            'TargetPrefix': 's3logs/' + bucket
+                                        }
+                                    }
+                                )
+                        else:
+                            logging.info("No S3 Bucket WITHOUT Logging enabled on account " + org_account + " region " + aws_region)
+                    else: 
+                        logging.info("No S3 Buckets found within account " + org_account + ", region " + aws_region + ":")
+                except Exception as exception_handle:
+                    logging.error(exception_handle)
+
+
+# 8. Turn on LB Logging.
+def lb_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts):
+    """Function to turn on Load Balancer Logs"""
+    for org_account in OrgAccountIdList:
+        if excluded_accounts != 'none' and org_account in excluded_accounts:
+            continue
+        elif included_accounts == 'all' or org_account in included_accounts:
+            for aws_region in region_list:
+                logging.info("Checking for Load Balancer Logging in the account "  + org_account + " in region " + aws_region + ".")
+                sts = boto3.client('sts')
+                RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
+                logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
+                assisted_log_enabler_sts = sts.assume_role(
+                    RoleArn=RoleArn,
+                    RoleSessionName='assisted-log-enabler-activation',
+                    DurationSeconds=3600,
+                )
+                elbv1_ma = boto3.client(
+                'elb',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                elbv2_ma = boto3.client(
+                'elbv2',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                s3_ma = boto3.client(
+                's3',
+                aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
+                aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
+                aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
+                region_name=aws_region
+                )
+                try:
+                    ELBList1: list = []
+                    ELBList2: list = []
+                    ELBLogList: list = []
+                    ELBv1LogList: list = []
+                    ELBv2LogList: list = []
+                    logging.info("DescribeLoadBalancers API Call")
+                    ELBList1 = elbv1_ma.describe_load_balancers()
+                    for lb in ELBList1['LoadBalancerDescriptions']:
+                        logging.info("DescribeLoadBalancerAttibute API Call")
+                        lblog=elbv1_ma.describe_load_balancer_attributes(LoadBalancerName=lb['LoadBalancerName'])
+                        logging.info("Parsing out for ELB Access Logging")
+                        if lblog['LoadBalancerAttributes']['AccessLog']['Enabled'] == False:
+                            ELBv1LogList.append([lb['LoadBalancerName'],'classic'])
+                    logging.info("DescribeLoadBalancers v2 API Call")
+                    ELBList2 = elbv2_ma.describe_load_balancers()
+                    for lb in ELBList2['LoadBalancers']:
+                        logging.info("DescribeLoadBalancerAttibute v2 API Call")
+                        lblog=elbv2_ma.describe_load_balancer_attributes(LoadBalancerArn=lb['LoadBalancerArn'])
+                        logging.info("Parsing out for ELBv2 Access Logging")
+                        for lbtemp in lblog['Attributes']:
+                            if lbtemp['Key'] == 'access_logs.s3.enabled':
+                                if lbtemp['Value'] == 'false':
+                                    ELBv2LogList.append([lb['LoadBalancerName'],lb['LoadBalancerArn']])
+                    ELBLogList=ELBv1LogList+ELBv2LogList      
+                    if ELBLogList != []:
+                        logging.info("List of Load Balancers found within account " + org_account + ", region " + aws_region + " without logging enabled:")
+                        print(ELBLogList)
+                        for elb in ELBLogList:
+                            logging.info(elb[0] + " does not have Load Balancer logging on. It will be turned on within this function.")
+                        logging.info("Creating S3 Logging Bucket for Load Balancers")
+                        """Function to create the bucket for storing load balancer logs"""
                         logging.info("Creating bucket in %s" % org_account)
                         logging.info("CreateBucket API Call")
                         if aws_region == 'us-east-1':
                             logging_bucket_dict = s3_ma.create_bucket(
-                                Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end
+                                Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end
                             )
                         else:
                             logging_bucket_dict = s3_ma.create_bucket(
-                                Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                                Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
                                 CreateBucketConfiguration={
                                     'LocationConstraint': aws_region
                                 }
                             )
-                        logging.info("Bucket " + "aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end + " Created.")
+                        logging.info("Bucket " + "aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end + " Created.")
                         logging.info("Setting lifecycle policy.")
                         logging.info("PutBucketLifecycleConfiguration API Call")
                         lifecycle_policy = s3_ma.put_bucket_lifecycle_configuration(
-                            Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                            Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
                             LifecycleConfiguration={
                                 'Rules': [
                                     {
@@ -433,10 +598,60 @@ def s3_logs(region_list, account_number, OrgAccountIdList, unique_end):
                             }
                         )
                         logging.info("Lifecycle Policy successfully set.")
+                        logging.info("Checking for AWS Log Account for ELB.")
+                        logging.info("https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html")
+                        if aws_region == 'us-east-1':
+                            elb_account='127311923021'
+                        elif aws_region == 'us-east-2':
+                            elb_account='033677994240'
+                        elif aws_region == 'us-west-1':
+                            elb_account='027434742980'
+                        elif aws_region == 'us-west-2':
+                            elb_account='797873946194'
+                        elif aws_region == 'af-south-1':
+                            elb_account='098369216593'
+                        elif aws_region == 'ca-central-1':
+                            elb_account='985666609251'
+                        elif aws_region == 'eu-central-1':
+                            elb_account='054676820928'
+                        elif aws_region == 'eu-west-1':
+                            elb_account='156460612806'
+                        elif aws_region == 'eu-west-2':
+                            elb_account='652711504416'
+                        elif aws_region == 'eu-south-1':
+                            elb_account='635631232127'
+                        elif aws_region == 'eu-west-3':
+                            elb_account='009996457667'
+                        elif aws_region == 'eu-north-1':
+                            elb_account='897822967062'
+                        elif aws_region == 'ap-east-1':
+                            elb_account='754344448648'
+                        elif aws_region == 'ap-northeast-1':
+                            elb_account='582318560864'
+                        elif aws_region == 'ap-northeast-2':
+                            elb_account='600734575887'
+                        elif aws_region == 'ap-northeast-3':
+                            elb_account='383597477331'
+                        elif aws_region == 'ap-southeast-1':
+                            elb_account='114774131450'
+                        elif aws_region == 'ap-southeast-2':
+                            elb_account='783225319266'
+                        elif aws_region == 'ap-south-1':
+                            elb_account='718504428378'
+                        elif aws_region == 'me-south-1':
+                            elb_account='076674570225'
+                        elif aws_region == 'sa-east-1':
+                            elb_account='507241528517'
+                        logging.info("Checking for AWS Log Account for ELB.")
+                        logging.info("PutBucketPolicy API Call")
+                        bucket_policy = s3_ma.put_bucket_policy(
+                            Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                            Policy='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"Service": "delivery.logs.amazonaws.com"},"Action": "s3:GetBucketAcl","Resource": "arn:aws:s3:::aws-lb-log-collection-' + org_account + '-' + aws_region + '-' + unique_end + '"},{"Effect": "Allow","Principal": {"Service": "delivery.logs.amazonaws.com"},"Action": "s3:PutObject","Resource": "arn:aws:s3:::aws-lb-log-collection-' + org_account + '-' + aws_region + '-' + unique_end + '/*","Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}},{"Effect": "Allow","Principal": {"AWS": "arn:aws:iam::' + elb_account + ':root"},"Action": "s3:PutObject","Resource": "arn:aws:s3:::aws-lb-log-collection-' + org_account + '-' + aws_region + '-' + unique_end + '/*"}]}'
+                        )
                         logging.info("Setting the S3 bucket Public Access to Blocked")
                         logging.info("PutPublicAccessBlock API Call")
                         bucket_private = s3_ma.put_public_access_block(
-                            Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                            Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
                             PublicAccessBlockConfiguration={
                                 'BlockPublicAcls': True,
                                 'IgnorePublicAcls': True,
@@ -444,257 +659,58 @@ def s3_logs(region_list, account_number, OrgAccountIdList, unique_end):
                                 'RestrictPublicBuckets': True
                             },
                         )
-                        logging.info("GetBucketAcl API Call")
-                        id=s3_ma.get_bucket_acl(Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end)['Owner']['ID']
-                        logging.info("PutBucketAcl API Call")
-                        s3_ma.put_bucket_acl(Bucket="aws-s3-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,GrantReadACP='uri=http://acs.amazonaws.com/groups/s3/LogDelivery',GrantWrite='uri=http://acs.amazonaws.com/groups/s3/LogDelivery',GrantFullControl='id=' + id)
-                        for bucket in S3LogList:
-                            logging.info("Activating logs for S3 Bucket " + bucket)
-                            logging.info("PutBucketLogging API Call")
-                            create_s3_log = s3_ma.put_bucket_logging(
-                                Bucket=bucket,
-                                BucketLoggingStatus={
-                                    'LoggingEnabled': {
-                                        'TargetBucket': 'aws-s3-log-collection-' + org_account + '-' + aws_region + '-' + unique_end,
-                                        'TargetGrants': [
-                                            {
-                                                'Permission': 'FULL_CONTROL',
-                                                'Grantee': {
-                                                    'Type': 'Group',
-                                                    'URI': 'http://acs.amazonaws.com/groups/s3/LogDelivery'
-                                                },
-                                            },
-                                        ],
-                                        'TargetPrefix': 's3logs/' + bucket
+                        if ELBv1LogList != []:
+                            for elb in ELBv1LogList:
+                                logging.info("Activating logs for Load Balancer " + elb[0])
+                                logging.info("ModifyLoadBalancerAttributes API Call")
+                                create_lb_log = elbv1_ma.modify_load_balancer_attributes(
+                                    LoadBalancerName=elb[0],
+                                    LoadBalancerAttributes={
+                                        'AccessLog': {
+                                            'Enabled': True,
+                                            'S3BucketName': "aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
+                                            'EmitInterval': 5,
+                                            'S3BucketPrefix': elb[0]
+                                        }
                                     }
-                                }
-                            )
-                    else:
-                        logging.info("No S3 Bucket WITHOUT Logging enabled on account " + org_account + " region " + aws_region)
-                else: 
-                    logging.info("No S3 Buckets found within account " + org_account + ", region " + aws_region + ":")
-            except Exception as exception_handle:
-                logging.error(exception_handle)
-
-
-# 8. Turn on LB Logging.
-def lb_logs(region_list, account_number, OrgAccountIdList, unique_end):
-    """Function to turn on Load Balancer Logs"""
-    for org_account in OrgAccountIdList:
-        for aws_region in region_list:
-            logging.info("Checking for Load Balancer Logging in the account "  + org_account + " in region " + aws_region + ".")
-            sts = boto3.client('sts')
-            RoleArn = 'arn:aws:iam::%s:role/Assisted_Log_Enabler_IAM_Role' % org_account
-            logging.info('Assuming Target Role %s for Assisted Log Enabler...' % RoleArn)
-            assisted_log_enabler_sts = sts.assume_role(
-                RoleArn=RoleArn,
-                RoleSessionName='assisted-log-enabler-activation',
-                DurationSeconds=3600,
-            )
-            elbv1_ma = boto3.client(
-            'elb',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            elbv2_ma = boto3.client(
-            'elbv2',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            s3_ma = boto3.client(
-            's3',
-            aws_access_key_id=assisted_log_enabler_sts['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assisted_log_enabler_sts['Credentials']['SecretAccessKey'],
-            aws_session_token=assisted_log_enabler_sts['Credentials']['SessionToken'],
-            region_name=aws_region
-            )
-            try:
-                ELBList1: list = []
-                ELBList2: list = []
-                ELBLogList: list = []
-                ELBv1LogList: list = []
-                ELBv2LogList: list = []
-                logging.info("DescribeLoadBalancers API Call")
-                ELBList1 = elbv1_ma.describe_load_balancers()
-                for lb in ELBList1['LoadBalancerDescriptions']:
-                    logging.info("DescribeLoadBalancerAttibute API Call")
-                    lblog=elbv1_ma.describe_load_balancer_attributes(LoadBalancerName=lb['LoadBalancerName'])
-                    logging.info("Parsing out for ELB Access Logging")
-                    if lblog['LoadBalancerAttributes']['AccessLog']['Enabled'] == False:
-                        ELBv1LogList.append([lb['LoadBalancerName'],'classic'])
-                logging.info("DescribeLoadBalancers v2 API Call")
-                ELBList2 = elbv2_ma.describe_load_balancers()
-                for lb in ELBList2['LoadBalancers']:
-                    logging.info("DescribeLoadBalancerAttibute v2 API Call")
-                    lblog=elbv2_ma.describe_load_balancer_attributes(LoadBalancerArn=lb['LoadBalancerArn'])
-                    logging.info("Parsing out for ELBv2 Access Logging")
-                    for lbtemp in lblog['Attributes']:
-                        if lbtemp['Key'] == 'access_logs.s3.enabled':
-                            if lbtemp['Value'] == 'false':
-                                ELBv2LogList.append([lb['LoadBalancerName'],lb['LoadBalancerArn']])
-                ELBLogList=ELBv1LogList+ELBv2LogList      
-                if ELBLogList != []:
-                    logging.info("List of Load Balancers found within account " + org_account + ", region " + aws_region + " without logging enabled:")
-                    print(ELBLogList)
-                    for elb in ELBLogList:
-                        logging.info(elb[0] + " does not have Load Balancer logging on. It will be turned on within this function.")
-                    logging.info("Creating S3 Logging Bucket for Load Balancers")
-                    """Function to create the bucket for storing load balancer logs"""
-                    logging.info("Creating bucket in %s" % org_account)
-                    logging.info("CreateBucket API Call")
-                    if aws_region == 'us-east-1':
-                        logging_bucket_dict = s3_ma.create_bucket(
-                            Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end
-                        )
-                    else:
-                        logging_bucket_dict = s3_ma.create_bucket(
-                            Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
-                            CreateBucketConfiguration={
-                                'LocationConstraint': aws_region
-                            }
-                        )
-                    logging.info("Bucket " + "aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end + " Created.")
-                    logging.info("Setting lifecycle policy.")
-                    logging.info("PutBucketLifecycleConfiguration API Call")
-                    lifecycle_policy = s3_ma.put_bucket_lifecycle_configuration(
-                        Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
-                        LifecycleConfiguration={
-                            'Rules': [
-                                {
-                                    'Expiration': {
-                                        'Days': 365
-                                    },
-                                    'Status': 'Enabled',
-                                    'Prefix': '',
-                                    'ID': 'LogStorage',
-                                    'Transitions': [
+                                )
+                                logging.info("Logging Enabled for Load Balancer " + elb[0])
+                        if ELBv2LogList != []:
+                            for elb in ELBv2LogList:
+                                logging.info("Activating logs for Load Balancer " + elb[0])
+                                logging.info("ModifyLoadBalancerAttributes v2 API Call")
+                                create_lb_log = elbv2_ma.modify_load_balancer_attributes(
+                                    LoadBalancerArn=elb[1],
+                                    Attributes=[
                                         {
-                                            'Days': 90,
-                                            'StorageClass': 'INTELLIGENT_TIERING'
+                                            'Key': 'access_logs.s3.enabled',
+                                            'Value': 'true'
+                                        },
+                                        {
+                                            'Key': 'access_logs.s3.bucket',
+                                            'Value': "aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end
+                                        },
+                                        {
+                                            'Key': 'access_logs.s3.prefix',
+                                            'Value': elb[0]
                                         }
                                     ]
-                                }
-                            ]
-                        }
-                    )
-                    logging.info("Lifecycle Policy successfully set.")
-                    logging.info("Checking for AWS Log Account for ELB.")
-                    logging.info("https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html")
-                    if aws_region == 'us-east-1':
-                        elb_account='127311923021'
-                    elif aws_region == 'us-east-2':
-                        elb_account='033677994240'
-                    elif aws_region == 'us-west-1':
-                        elb_account='027434742980'
-                    elif aws_region == 'us-west-2':
-                        elb_account='797873946194'
-                    elif aws_region == 'af-south-1':
-                        elb_account='098369216593'
-                    elif aws_region == 'ca-central-1':
-                        elb_account='985666609251'
-                    elif aws_region == 'eu-central-1':
-                        elb_account='054676820928'
-                    elif aws_region == 'eu-west-1':
-                        elb_account='156460612806'
-                    elif aws_region == 'eu-west-2':
-                        elb_account='652711504416'
-                    elif aws_region == 'eu-south-1':
-                        elb_account='635631232127'
-                    elif aws_region == 'eu-west-3':
-                        elb_account='009996457667'
-                    elif aws_region == 'eu-north-1':
-                        elb_account='897822967062'
-                    elif aws_region == 'ap-east-1':
-                        elb_account='754344448648'
-                    elif aws_region == 'ap-northeast-1':
-                        elb_account='582318560864'
-                    elif aws_region == 'ap-northeast-2':
-                        elb_account='600734575887'
-                    elif aws_region == 'ap-northeast-3':
-                        elb_account='383597477331'
-                    elif aws_region == 'ap-southeast-1':
-                        elb_account='114774131450'
-                    elif aws_region == 'ap-southeast-2':
-                        elb_account='783225319266'
-                    elif aws_region == 'ap-south-1':
-                        elb_account='718504428378'
-                    elif aws_region == 'me-south-1':
-                        elb_account='076674570225'
-                    elif aws_region == 'sa-east-1':
-                        elb_account='507241528517'
-                    logging.info("Checking for AWS Log Account for ELB.")
-                    logging.info("PutBucketPolicy API Call")
-                    bucket_policy = s3_ma.put_bucket_policy(
-                        Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
-                        Policy='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"Service": "delivery.logs.amazonaws.com"},"Action": "s3:GetBucketAcl","Resource": "arn:aws:s3:::aws-lb-log-collection-' + org_account + '-' + aws_region + '-' + unique_end + '"},{"Effect": "Allow","Principal": {"Service": "delivery.logs.amazonaws.com"},"Action": "s3:PutObject","Resource": "arn:aws:s3:::aws-lb-log-collection-' + org_account + '-' + aws_region + '-' + unique_end + '/*","Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}},{"Effect": "Allow","Principal": {"AWS": "arn:aws:iam::' + elb_account + ':root"},"Action": "s3:PutObject","Resource": "arn:aws:s3:::aws-lb-log-collection-' + org_account + '-' + aws_region + '-' + unique_end + '/*"}]}'
-                    )
-                    logging.info("Setting the S3 bucket Public Access to Blocked")
-                    logging.info("PutPublicAccessBlock API Call")
-                    bucket_private = s3_ma.put_public_access_block(
-                        Bucket="aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
-                        PublicAccessBlockConfiguration={
-                            'BlockPublicAcls': True,
-                            'IgnorePublicAcls': True,
-                            'BlockPublicPolicy': True,
-                            'RestrictPublicBuckets': True
-                        },
-                    )
-                    if ELBv1LogList != []:
-                        for elb in ELBv1LogList:
-                            logging.info("Activating logs for Load Balancer " + elb[0])
-                            logging.info("ModifyLoadBalancerAttributes API Call")
-                            create_lb_log = elbv1_ma.modify_load_balancer_attributes(
-                                LoadBalancerName=elb[0],
-                                LoadBalancerAttributes={
-                                    'AccessLog': {
-                                        'Enabled': True,
-                                        'S3BucketName': "aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end,
-                                        'EmitInterval': 5,
-                                        'S3BucketPrefix': elb[0]
-                                    }
-                                }
-                            )
-                            logging.info("Logging Enabled for Load Balancer " + elb[0])
-                    if ELBv2LogList != []:
-                        for elb in ELBv2LogList:
-                            logging.info("Activating logs for Load Balancer " + elb[0])
-                            logging.info("ModifyLoadBalancerAttributes v2 API Call")
-                            create_lb_log = elbv2_ma.modify_load_balancer_attributes(
-                                LoadBalancerArn=elb[1],
-                                Attributes=[
-                                    {
-                                        'Key': 'access_logs.s3.enabled',
-                                        'Value': 'true'
-                                    },
-                                    {
-                                        'Key': 'access_logs.s3.bucket',
-                                        'Value': "aws-lb-log-collection-" + org_account + "-" + aws_region + "-" + unique_end
-                                    },
-                                    {
-                                        'Key': 'access_logs.s3.prefix',
-                                        'Value': elb[0]
-                                    }
-                                ]
-                            )
-                            logging.info("Logging Enabled for Load Balancer " + elb[0])
-                else: 
-                    logging.info("No Load Balancers WITHOUT logging found within account " + org_account + ", region " + aws_region + ":")
-            except Exception as exception_handle:
-                logging.error(exception_handle)
+                                )
+                                logging.info("Logging Enabled for Load Balancer " + elb[0])
+                    else: 
+                        logging.info("No Load Balancers WITHOUT logging found within account " + org_account + ", region " + aws_region + ":")
+                except Exception as exception_handle:
+                    logging.error(exception_handle)
 
 
-def run_eks():
+def run_eks(included_accounts='all', excluded_accounts='none'):
     """Function that runs the defined EKS logging code"""
     OrgAccountIdList, organization_id = org_account_grab()
-    eks_logging(region_list, OrgAccountIdList)
+    eks_logging(region_list, OrgAccountIdList, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
 
-def run_vpc_flow_logs(bucket_name='default'):
+def run_vpc_flow_logs(bucket_name='default', included_accounts='all', excluded_accounts='none'):
     """Function that runs the defined VPC Flow Log logging code"""
     OrgAccountIdList, organization_id = org_account_grab()
     account_number = get_account_number()
@@ -704,11 +720,11 @@ def run_vpc_flow_logs(bucket_name='default'):
     else:
         update_custom_bucket_policy(bucket_name, account_number)
     
-    flow_log_activator(OrgAccountIdList, region_list, bucket_name)
+    flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
     
 
-def run_r53_query_logs(bucket_name='default'):
+def run_r53_query_logs(bucket_name='default', included_accounts='all', excluded_accounts='none'):
     """Function that runs the defined R53 Query Logging code"""
     OrgAccountIdList, organization_id = org_account_grab()
     account_number = get_account_number()
@@ -718,26 +734,26 @@ def run_r53_query_logs(bucket_name='default'):
     else:
         update_custom_bucket_policy(bucket_name, account_number)
     
-    route_53_query_logs(region_list, OrgAccountIdList, bucket_name)
+    route_53_query_logs(region_list, OrgAccountIdList, bucket_name, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def run_s3_logs():
+def run_s3_logs(included_accounts='all', excluded_accounts='none'):
     """Function that runs the defined Bucket Logging code"""
     unique_end = random_string_generator()
     account_number = get_account_number()
     OrgAccountIdList, organization_id = org_account_grab()
-    s3_logs(region_list, account_number, OrgAccountIdList, unique_end)
+    s3_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def run_lb_logs():
+def run_lb_logs(included_accounts='all', excluded_accounts='none'):
     """Function that runs the defined Load Balancer Logging code"""
     unique_end = random_string_generator()
     account_number = get_account_number()
     OrgAccountIdList, organization_id = org_account_grab()
-    lb_logs(region_list, account_number, OrgAccountIdList, unique_end)
+    lb_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def lambda_handler(event, context, bucket_name='default'):
+def lambda_handler(event, context, bucket_name='default', included_accounts='all', excluded_accounts='none'):
     """Function that runs all of the previously defined functions"""
     unique_end = random_string_generator()
     account_number = get_account_number()
@@ -746,11 +762,11 @@ def lambda_handler(event, context, bucket_name='default'):
         bucket_name = create_bucket(organization_id, account_number, unique_end)
     else:
         update_custom_bucket_policy(bucket_name, account_number)
-    flow_log_activator(OrgAccountIdList, region_list, bucket_name)
-    eks_logging(region_list, OrgAccountIdList)
-    route_53_query_logs(region_list, OrgAccountIdList, bucket_name)
-    s3_logs(region_list, account_number, OrgAccountIdList, unique_end)
-    lb_logs(region_list, account_number, OrgAccountIdList, unique_end)
+    flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts)
+    eks_logging(region_list, OrgAccountIdList, included_accounts, excluded_accounts)
+    route_53_query_logs(region_list, OrgAccountIdList, bucket_name, included_accounts, excluded_accounts)
+    s3_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts)
+    lb_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
 

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -670,6 +670,115 @@ def check_guardduty():
         except Exception as exception_handle:
             logging.error(exception_handle)
 
+def wafv2_logs():
+    """Function to turn on WAFv2 Logging"""
+    account_number = sts.get_caller_identity()["Account"]
+    bucket_arn = ""
+    for aws_region in region_list:
+        wafv2 = boto3.client('wafv2', region_name=aws_region)
+        logging.info("Checking for WAFv2 Logging in the account " + account_number + ", region " + aws_region)
+        try:
+            WAFv2List: list = [] # list of all WAFv2 ARNs
+            WAFv2LogList: list = [] # list of WAFv2 ARNs with logging enabled
+            WAFv2NoLogList: list = [] # list of WAFv2 ARNs to enable logging
+
+            # Get regional WAFv2 Web ACLs
+            logging.info("ListWebAcls API Call")
+            wafv2_regional_acl_list = wafv2.list_web_acls(Scope='REGIONAL')["WebACLs"]
+            for acl in wafv2_regional_acl_list:
+                WAFv2List.append(acl["ARN"])
+            
+            if aws_region == 'us-east-1':
+                # Get CloudFront (global) WAFv2 Web ACLs
+                logging.info("Checking for Global (CloudFront) Web ACLs")
+                logging.info("ListWebAcls API Call")
+                wafv2_cf_acl_list = wafv2.list_web_acls(Scope='CLOUDFRONT')["WebACLs"]
+                for acl in wafv2_cf_acl_list:
+                    WAFv2List.append(acl["ARN"])
+            
+            logging.info("List of Web ACLs found within account " + account_number + ", region " + aws_region + ":")
+            print(WAFv2List)
+
+            logging.info("ListLoggingConfigurations API Call")
+            wafv2_regional_log_configs = wafv2.list_logging_configurations(Scope='REGIONAL')["LoggingConfigurations"]
+            for acl in wafv2_regional_log_configs:
+                WAFv2LogList.append(acl["ResourceArn"])
+            
+            if aws_region == 'us-east-1':
+                logging.info("Checking Global (CloudFront) Web ACL Logging Configurations")
+                logging.info("ListLoggingConfigurations API Call")
+                wafv2_cf_log_configs = wafv2.list_logging_configurations(Scope='CLOUDFRONT')["LoggingConfigurations"]
+                for acl in wafv2_cf_log_configs:
+                    WAFv2LogList.append(acl["ResourceArn"])
+            
+            WAFv2NoLogList = list(set(WAFv2List) - set(WAFv2LogList))
+            logging.info("List of Web ACLs found within account " + account_number + ", region " + aws_region + " WITHOUT logging enabled:")
+            print(WAFv2NoLogList)
+
+            # If an S3 bucket hasn't been created yet, create one
+            if WAFv2NoLogList != [] and bucket_arn == "":
+                logging.info("Creating S3 bucket for WAF logs enabled by Assisted Log Enabler.")
+                unique_end = random_string_generator()
+                bucket_name = "aws-waf-logs-ale-" + account_number + "-" + unique_end
+                logging.info("CreateBucket API Call")
+                s3.create_bucket(Bucket=bucket_name)
+                logging.info("Bucket " + bucket_name + " created.")
+                bucket_arn = "arn:aws:s3:::" + bucket_name
+                
+                logging.info("Setting lifecycle policy.")
+                logging.info("PutBucketLifecycleConfiguration API Call")
+                s3.put_bucket_lifecycle_configuration(
+                    Bucket=bucket_name,
+                    LifecycleConfiguration={
+                        'Rules': [
+                            {
+                                'Expiration': {
+                                    'Days': 365
+                                },
+                                'Status': 'Enabled',
+                                'Prefix': '',
+                                'ID': 'LogStorage',
+                                'Transitions': [
+                                    {
+                                        'Days': 90,
+                                        'StorageClass': 'INTELLIGENT_TIERING'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                )
+                logging.info("Setting the S3 bucket Public Access to Blocked")
+                logging.info("PutPublicAccessBlock API Call")
+                bucket_private = s3.put_public_access_block(
+                    Bucket=bucket_name,
+                    PublicAccessBlockConfiguration={
+                        'BlockPublicAcls': True,
+                        'IgnorePublicAcls': True,
+                        'BlockPublicPolicy': True,
+                        'RestrictPublicBuckets': True
+                    },
+                )
+            
+            # If an S3 bucket has been created, use it as the log destination
+            if WAFv2NoLogList != [] and bucket_arn != "":
+                for arn in WAFv2NoLogList:
+                    logging.info(arn + " does not have logging turned on. Turning on logging.")
+                    logging.info("PutLoggingConfiguration API Call")
+                    wafv2.put_logging_configuration(
+                        LoggingConfiguration={
+                            'ResourceArn': arn,
+                            'LogDestinationConfigs': [ 
+                                bucket_arn, 
+                            ]
+                        }
+                    )
+            else:
+                logging.info("No WAFv2 Web ACLs to enable logging for in account " + account_number + ", region " + aws_region + ".")
+
+        except Exception as exception_handle:
+            logging.error(exception_handle)
+
 
 def run_eks():
     """Function that runs the defined EKS logging code"""
@@ -725,6 +834,11 @@ def run_guardduty():
     check_guardduty()
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
+def run_wafv2_logs():
+    """Functio that runs the defined WAFv2 Logging code"""
+    wafv2_logs()
+    logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
+
 def lambda_handler(event, context, bucket_name='default'):
     """Function that runs all of the previously defined functions"""
     unique_end = random_string_generator()
@@ -740,6 +854,7 @@ def lambda_handler(event, context, bucket_name='default'):
     s3_logs(region_list, unique_end)
     lb_logs(region_list, unique_end)
     check_guardduty()
+    wafv2_logs()
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
 

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -88,7 +88,7 @@ def create_bucket(unique_end):
         logging.info("PutBucketPolicy API Call")
         bucket_policy = s3.put_bucket_policy(
             Bucket=bucket_name,
-            Policy='{"Version": "2012-10-17", "Statement": [{"Sid": "AWSCloudTrailAclCheck20150319","Effect": "Allow","Principal": {"Service": "cloudtrail.amazonaws.com"},"Action": "s3:GetBucketAcl","Resource": "arn:aws:s3:::' + bucket_name + '"},{"Sid": "AWSCloudTrailWrite20150319","Effect": "Allow","Principal": {"Service": "cloudtrail.amazonaws.com"},"Action": "s3:PutObject","Resource": "arn:aws:s3:::' + bucket_name + '/cloudtrail/AWSLogs/' + account_number + '/*","Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}}]}'
+            Policy='{ "Version": "2012-10-17", "Statement": [ { "Sid": "AWSCloudTrailAclCheck20150319", "Effect": "Allow", "Principal": { "Service": "cloudtrail.amazonaws.com" }, "Action": "s3:GetBucketAcl", "Resource": "arn:aws:s3:::' + bucket_name + '" }, { "Sid": "AWSCloudTrailWrite20150319", "Effect": "Allow", "Principal": { "Service": "cloudtrail.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/cloudtrail/AWSLogs/' + account_number + '/*", "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } }, { "Sid": "AWSLogDeliveryAclCheck", "Effect": "Allow", "Principal": { "Service": "delivery.logs.amazonaws.com" }, "Action": "s3:GetBucketAcl", "Resource": "arn:aws:s3:::' + bucket_name + '" }, { "Sid": "AWSLogDeliveryWriteVPC", "Effect": "Allow", "Principal": { "Service": "delivery.logs.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/vpcflowlogs/*", "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } }, { "Sid": "AWSLogDeliveryWriteR53", "Effect": "Allow", "Principal": { "Service": "delivery.logs.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/r53querylogs/*", "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } }, { "Sid": "Deny non-HTTPS access", "Effect": "Deny", "Principal": { "Service": "guardduty.amazonaws.com" }, "Action": "s3:*", "Resource": "arn:aws:s3:::' + bucket_name + '/guardduty/*", "Condition": { "Bool": { "aws:SecureTransport": "false" } } }, { "Sid": "Allow PutObject", "Effect": "Allow", "Principal": { "Service": "guardduty.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/guardduty/*" }, { "Sid": "Allow GetBucketLocation", "Effect": "Allow", "Principal": { "Service": "guardduty.amazonaws.com" }, "Action": "s3:GetBucketLocation", "Resource": "arn:aws:s3:::' + bucket_name + '" } ] }'
         )
         logging.info("Setting the S3 bucket Public Access to Blocked")
         logging.info("PutPublicAccessBlock API Call")
@@ -105,6 +105,14 @@ def create_bucket(unique_end):
         logging.error(exception_handle)
     return bucket_name
 
+# If custom bucket is supplied, update the bucket policy
+def update_custom_bucket_policy(bucket_name, account_number):
+    logging.info("Pre-existing S3 bucket specified. Updating bucket policy.")
+    logging.info("PutBucketPolicy API Call")
+    s3.put_bucket_policy(
+            Bucket=bucket_name,
+            Policy='{ "Version": "2012-10-17", "Statement": [ { "Sid": "AWSCloudTrailAclCheck20150319", "Effect": "Allow", "Principal": { "Service": "cloudtrail.amazonaws.com" }, "Action": "s3:GetBucketAcl", "Resource": "arn:aws:s3:::' + bucket_name + '" }, { "Sid": "AWSCloudTrailWrite20150319", "Effect": "Allow", "Principal": { "Service": "cloudtrail.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/cloudtrail/AWSLogs/' + account_number + '/*", "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } }, { "Sid": "AWSLogDeliveryAclCheck", "Effect": "Allow", "Principal": { "Service": "delivery.logs.amazonaws.com" }, "Action": "s3:GetBucketAcl", "Resource": "arn:aws:s3:::' + bucket_name + '" }, { "Sid": "AWSLogDeliveryWriteVPC", "Effect": "Allow", "Principal": { "Service": "delivery.logs.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/vpcflowlogs/*", "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } }, { "Sid": "AWSLogDeliveryWriteR53", "Effect": "Allow", "Principal": { "Service": "delivery.logs.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/r53querylogs/*", "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } }, { "Sid": "Deny non-HTTPS access", "Effect": "Deny", "Principal": { "Service": "guardduty.amazonaws.com" }, "Action": "s3:*", "Resource": "arn:aws:s3:::' + bucket_name + '/guardduty/*", "Condition": { "Bool": { "aws:SecureTransport": "false" } } }, { "Sid": "Allow PutObject", "Effect": "Allow", "Principal": { "Service": "guardduty.amazonaws.com" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::' + bucket_name + '/guardduty/*" }, { "Sid": "Allow GetBucketLocation", "Effect": "Allow", "Principal": { "Service": "guardduty.amazonaws.com" }, "Action": "s3:GetBucketLocation", "Resource": "arn:aws:s3:::' + bucket_name + '" } ] }'
+        )
 
 # 2. Find VPCs and turn flow logs on if not on already.
 def flow_log_activator(region_list, account_number, bucket_name):
@@ -158,7 +166,7 @@ def flow_log_activator(region_list, account_number, bucket_name):
 
 
 # 3. Check to see if a CloudTrail trail is configured, and turn it on if it is not.
-def check_cloudtrail(account_number, bucket_name, custom_bucket):
+def check_cloudtrail(account_number, bucket_name):
     """Function to check if CloudTrail is enabled"""
     logging.info("Checking to see if CloudTrail is on, and will activate if needed.")
     try:
@@ -166,45 +174,7 @@ def check_cloudtrail(account_number, bucket_name, custom_bucket):
         cloudtrail_status = cloudtrail.describe_trails(
             includeShadowTrails=True
         )
-        if cloudtrail_status["trailList"][0]["Name"] == "":
-            if custom_bucket:
-                logging.info("Pre-existing S3 bucket specified: checking if the bucket policy allows CloudTrail to access the bucket.")
-
-                statement1 = {"Sid": "AWSCloudTrailAclCheck20150319","Effect": "Allow","Principal": {"Service": "cloudtrail.amazonaws.com"},"Action": "s3:GetBucketAcl","Resource": "arn:aws:s3:::" + bucket_name }
-                statement2 = {"Sid": "AWSCloudTrailWrite20150319","Effect": "Allow","Principal": {"Service": "cloudtrail.amazonaws.com"},"Action": "s3:PutObject","Resource": "arn:aws:s3:::" + bucket_name + "/cloudtrail/AWSLogs/" + account_number + "/*","Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}}
-                
-                logging.info("GetBucketPolicy API Call")
-                original_policy = s3.get_bucket_policy(Bucket=bucket_name)["Policy"]
-
-                policy = json.loads(original_policy)
-
-                if statement1["Sid"] in original_policy and statement2["Sid"] in original_policy:
-                    logging.info("Required statements already exist in the bucket policy for " + bucket_name)
-                else:
-                    if statement1["Sid"] not in original_policy:
-                        logging.info("Adding statement " + statement1["Sid"] + " to " + bucket_name + " bucket policy.")
-                        policy["Statement"].append(statement1)
-
-                        new_policy = json.dumps(policy)
-
-                        logging.info("PutBucketPolicy API Call")
-                        s3.put_bucket_policy(
-                            Bucket=bucket_name,
-                            Policy=new_policy
-                        )
-
-                    if statement2["Sid"] not in original_policy:
-                        logging.info("Adding statement " + statement2["Sid"] + " to " + bucket_name + " bucket policy.")
-                        policy["Statement"].append(statement2)
-
-                        new_policy = json.dumps(policy)
-
-                        logging.info("PutBucketPolicy API Call")
-                        s3.put_bucket_policy(
-                            Bucket=bucket_name,
-                            Policy=new_policy
-                        )
-
+        if cloudtrail_status["trailList"] == []:
             logging.info("CreateTrail API Call")
             cloudtrail_activate = cloudtrail.create_trail(
                 Name='assisted-log-enabler-ct-' + account_number,
@@ -634,10 +604,36 @@ def lb_logs(region_list, unique_end):
         except Exception as exception_handle:
             logging.error(exception_handle)
 
+def check_guardduty(region_list, account_number, bucket_name):
+    """Function to turn on GuardDuty and export findings to an S3 bucket."""
 
-def check_guardduty():
-    """Function to turn on GuardDuty"""
-    account_number = sts.get_caller_identity()["Account"]
+    logging.info("Creating KMS key for GuardDuty to export findings.")
+    kms = boto3.client('kms')
+    logging.info("CreateKey API Call")
+    export_key = kms.create_key(
+        Policy="{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\", \"Principal\": { \"AWS\": \"arn:aws:iam::" + account_number + ":root\" }, \"Action\": \"kms:*\", \"Resource\": \"*\" }, { \"Sid\": \"Allow GuardDuty to use the key\", \"Effect\": \"Allow\", \"Principal\": { \"Service\": \"guardduty.amazonaws.com\" }, \"Action\": \"kms:GenerateDataKey\", \"Resource\": \"*\" } ] }",
+        KeyUsage="ENCRYPT_DECRYPT",
+        KeySpec="SYMMETRIC_DEFAULT",
+        Origin="AWS_KMS",
+        MultiRegion=False
+    )
+    key_arn = export_key["KeyMetadata"]["Arn"]
+    logging.info("Created KMS Key " + key_arn)
+    key_alias = "alias/ale-guardduty-key-" + random_string_generator()
+    logging.info("CreateAlias API Call")
+    kms.create_alias(
+        AliasName=key_alias,
+        TargetKeyId=key_arn
+    )
+    logging.info("Created KMS Key Alias " + key_alias)
+
+    logging.info("Creating /guardduty folder in S3 Bucket")
+    logging.info("PutObject API Call")
+    s3.put_object(
+        Bucket=bucket_name,
+        Key="guardduty/"
+    )
+
     for aws_region in region_list:
         guardduty = boto3.client('guardduty', region_name=aws_region)
         logging.info("Checking for GuardDuty detector in the account " + account_number + ", region " + aws_region)
@@ -645,7 +641,7 @@ def check_guardduty():
             logging.info("ListDetectors API Call")
             detectors = guardduty.list_detectors()
             if detectors["DetectorIds"] == []:
-                logging.info("GuardDuty is not enabled in the account" + account_number + ", region " + aws_region)
+                logging.info("GuardDuty is not enabled in the account " + account_number + ", region " + aws_region)
                 logging.info("Enabling GuardDuty")
                 logging.info("CreateDetector API Call")
                 new_detector = guardduty.create_detector(
@@ -665,8 +661,46 @@ def check_guardduty():
                     }
                     )
                 logging.info("Created GuardDuty detector ID " + new_detector["DetectorId"])
+
+                logging.info("Exporting GuardDuty findings to an S3 bucket.")
+                logging.info("Setting S3 Bucket " + bucket_name + " as publishing destination for GuardDuty detector.")
+                logging.info("CreatePublishingDestination API Call")
+                guardduty.create_publishing_destination(
+                    DetectorId=new_detector["DetectorId"],
+                    DestinationType="S3",
+                    DestinationProperties={
+                        "DestinationArn": "arn:aws:s3:::" + bucket_name + "/guardduty",
+                        "KmsKeyArn": key_arn
+                    }
+                )
             else:
                 logging.info("GuardDuty is already enabled in the account " + account_number + ", region " + aws_region)
+                detector_id = detectors["DetectorIds"][0]
+                logging.info("Checking if GuardDuty detector publishes findings to S3.")
+                logging.info("ListPublishingDestinations API Call")
+                gd_destinations = guardduty.list_publishing_destinations(DetectorId=detector_id)["Destinations"]
+                if gd_destinations == []:
+                    logging.info("Detector does not publish findings to a destination. Setting S3 Bucket " + bucket_name + " as publishing destination for GuardDuty detector.")
+                    logging.info("CreatePublishingDestination API Call")
+                    guardduty.create_publishing_destination(
+                        DetectorId=detector_id,
+                        DestinationType="S3",
+                        DestinationProperties={
+                            "DestinationArn": "arn:aws:s3:::" + bucket_name + "/guardduty",
+                            "KmsKeyArn": key_arn
+                        }
+                    )
+                else:
+                    for dest in gd_destinations:
+                        if dest["DestinationType"] == "S3":
+                            dest_id = dest["DestinationId"]
+                            logging.info("DescribePublishingDestination API Call")
+                            dest_info = guardduty.describe_publishing_destination(
+                                DetectorId=detector_id,
+                                DestinationId=dest_id
+                            )
+                            dest_s3_arn = dest_info["DestinationProperties"]["DestinationArn"]
+                            logging.info("Detector already publishes findings to S3 bucket " + dest_s3_arn.split(":")[-1])
         except Exception as exception_handle:
             logging.error(exception_handle)
 
@@ -785,7 +819,6 @@ def run_eks():
     eks_logging(region_list)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-
 def run_cloudtrail(bucket_name='default'):
     """Function that runs the defined CloudTrail logging code"""
     custom_bucket = True
@@ -797,7 +830,6 @@ def run_cloudtrail(bucket_name='default'):
     check_cloudtrail(account_number, bucket_name, custom_bucket)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-
 def run_vpc_flow_logs(bucket_name='default'):
     """Function that runs the defined VPC Flow Log logging code"""
     if bucket_name == 'default':
@@ -807,7 +839,6 @@ def run_vpc_flow_logs(bucket_name='default'):
     flow_log_activator(region_list, account_number, bucket_name)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
     
-
 def run_r53_query_logs(bucket_name='default'):
     """Function that runs the defined R53 Query Logging code"""
     if bucket_name == 'default':
@@ -829,13 +860,19 @@ def run_lb_logs():
     lb_logs(region_list, unique_end)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def run_guardduty():
-    """Function that runs the defined GuardDuty enablement code"""
-    check_guardduty()
+def run_guardduty(bucket_name='default'):
+    """Function that runs the defined GuardDuty enablement code and exports findings to an S3 bucket"""
+    account_number = sts.get_caller_identity()["Account"]
+    if bucket_name == 'default':
+        unique_end = random_string_generator()
+        bucket_name = create_bucket(unique_end)
+    else:
+        update_custom_bucket_policy(bucket_name, account_number)
+    check_guardduty(region_list, account_number, bucket_name)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
 def run_wafv2_logs():
-    """Functio that runs the defined WAFv2 Logging code"""
+    """Function that runs the defined WAFv2 Logging code"""
     wafv2_logs()
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
@@ -843,17 +880,17 @@ def lambda_handler(event, context, bucket_name='default'):
     """Function that runs all of the previously defined functions"""
     unique_end = random_string_generator()
     account_number = sts.get_caller_identity()["Account"]
-    custom_bucket = True
     if bucket_name == 'default':
         bucket_name = create_bucket(unique_end)
-        custom_bucket = False
+    else:
+        update_custom_bucket_policy(bucket_name, account_number)
     flow_log_activator(region_list, account_number, bucket_name)
-    check_cloudtrail(account_number, bucket_name, custom_bucket)
+    check_cloudtrail(account_number, bucket_name)
     eks_logging(region_list)
     route_53_query_logs(region_list, account_number, bucket_name)
     s3_logs(region_list, unique_end)
     lb_logs(region_list, unique_end)
-    check_guardduty()
+    check_guardduty(region_list, account_number, bucket_name)
     wafv2_logs()
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 


### PR DESCRIPTION
GuardDuty feature now exports findings to an S3 bucket in single_account and multi_account modes. Will use a specified S3 bucket or create a new one if not specified. GuardDuty features are reflected in dryrun modes.

Added function to update policy of a specified S3 bucket in single_account mode which includes necessary permissions for GuardDuty exports, and is also used for CloudTrail log enablement.

Updated ALE cross-account role to have correct permissions for GuardDuty finding exports. Updated README and help message to reflect these changes.

Also updated check_cloudtrail in single_account mode to use a more accurate method of checking if a CloudTrail trail exists or not.

This pull request includes changes made in #50, #49, #48, #47, #46, #45.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
