### PR TITLE
Add functionality to enable a suspended GuardDuty detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 "s3:PutBucketLifecycleConfiguration",
 "guardduty:ListDetectors",
 "guardduty:TagResource",
+"guardduty:GetDetector",
 "guardduty:CreateDetector",
+"guardduty:UpdateDetector",
 "guardduty:ListPublishingDestinations",
 "guardduty:CreatePublishingDestination",
 "guardduty:DescribePublishingDestination",
@@ -145,8 +147,10 @@ The following permissions are needed within AWS IAM for Assisted Log Enabler for
 
 # For enabling GuardDuty and export findings:
 "guardduty:ListDetectors",
+"guardduty:GetDetector",
 "guardduty:TagResource",
 "guardduty:CreateDetector",
+"guardduty:UpdateDetector",
 "guardduty:ListPublishingDestinations",
 "guardduty:CreatePublishingDestination",
 "guardduty:DescribePublishingDestination",
@@ -219,6 +223,9 @@ python3 assisted_log_enabler.py
 ██      ██  ██ ██ ██   ██ ██   ██ ██      ██      ██   ██   
 ███████ ██   ████ ██   ██ ██████  ███████ ███████ ██   ██ 
          Joshua "DozerCat" McKiddy - Customer Incident Response Team (CIRT) - AWS
+         Cydney "StudyCat" Stude - Customer Incident Response Team (AWS) - Twitter: @cydneystude
+         Rogerio Kasa - Security Solutions Architect (AWS)
+         Andrew Yankowsky - Professional Services (AWS)
          Twitter: @jdubm31
          Type -h for help.
 

--- a/permissions/ALE_child_account_role.yaml
+++ b/permissions/ALE_child_account_role.yaml
@@ -73,8 +73,10 @@ Resources:
               - eks:ListClusters
               - ec2:CreateTags
               - guardduty:ListDetectors
+              - guardduty:GetDetector
               - guardduty:TagResource
               - guardduty:CreateDetector
+              - guardduty:UpdateDetector
               - guardduty:ListPublishingDestinations
               - guardduty:CreatePublishingDestination
               - guardduty:DescribePublishingDestination
@@ -98,7 +100,13 @@ Resources:
             Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty
             Condition:
               StringLike:
-                'iam:AWSServiceName': 'guardduty.amazonaws.com'
+                'iam:AWSServiceName': 
+                  - 'guardduty.amazonaws.com'
+                  - 'malware-protection.guardduty.amazonaws.com'
+          - Effect: Allow
+            Action:
+              - iam:GetRole
+            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/malware-protection.guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDutyMalwareProtection
           - Effect: Allow
             Action:
               - route53resolver:ListResolverQueryLogConfigs

--- a/subfunctions/ALE_dryrun_multi.py
+++ b/subfunctions/ALE_dryrun_multi.py
@@ -335,8 +335,15 @@ def dryrun_check_guardduty(region_list, OrgAccountIdList):
                     logging.info("Exporting GuardDuty findings to an S3 bucket.")
                     logging.info("Setting S3 Bucket as publishing destination for GuardDuty detector.")
                 else:
-                    logging.info("GuardDuty is already enabled in the account " + org_account + ", region " + aws_region)
                     detector_id = detectors["DetectorIds"][0]
+                    logging.info("GetDetector API Call")
+                    if guardduty_ma.get_detector(DetectorId=detector_id)["Status"] == "DISABLED":
+                        logging.info("GuardDuty is suspended in the account " + org_account + ", region " + aws_region)
+                        logging.info("Enabling GuardDuty")
+                        logging.info("UpdateDetector API Call")
+                    else:
+                        logging.info("GuardDuty is already enabled in the account " + org_account + ", region " + aws_region)
+
                     logging.info("Checking if GuardDuty detector publishes findings to S3.")
                     logging.info("ListPublishingDestinations API Call")
                     gd_destinations = guardduty_ma.list_publishing_destinations(DetectorId=detector_id)["Destinations"]

--- a/subfunctions/ALE_dryrun_single.py
+++ b/subfunctions/ALE_dryrun_single.py
@@ -220,8 +220,15 @@ def dryrun_check_guardduty(region_list, account_number):
                 logging.info("Exporting GuardDuty findings to an S3 bucket.")
                 logging.info("Setting S3 Bucket as publishing destination for GuardDuty detector.")
             else:
-                logging.info("GuardDuty is already enabled in the account " + account_number + ", region " + aws_region)
                 detector_id = detectors["DetectorIds"][0]
+                logging.info("GetDetector API Call")
+                if guardduty.get_detector(DetectorId=detector_id)["Status"] == "DISABLED":
+                    logging.info("GuardDuty is suspended in the account " + account_number + ", region " + aws_region)
+                    logging.info("Enabling GuardDuty")
+                    logging.info("UpdateDetector API Call")
+                else:
+                    logging.info("GuardDuty is already enabled in the account " + account_number + ", region " + aws_region)
+                
                 logging.info("Checking if GuardDuty detector publishes findings to S3.")
                 logging.info("ListPublishingDestinations API Call")
                 gd_destinations = guardduty.list_publishing_destinations(DetectorId=detector_id)["Destinations"]

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -679,8 +679,23 @@ def check_guardduty(region_list, account_number, bucket_name):
                     }
                 )
             else:
-                logging.info("GuardDuty is already enabled in the account " + account_number + ", region " + aws_region)
                 detector_id = detectors["DetectorIds"][0]
+                logging.info("GetDetector API Call")
+                if guardduty.get_detector(DetectorId=detector_id)["Status"] == "DISABLED":
+                    logging.info("GuardDuty is suspended in the account " + account_number + ", region " + aws_region)
+                    logging.info("Enabling GuardDuty")
+                    logging.info("UpdateDetector API Call")
+                    guardduty.update_detector(
+                        DetectorId=detector_id,
+                        Enable=True,
+                        DataSources={
+                            "S3Logs": {"Enable": True},
+                            "Kubernetes": {"AuditLogs": {"Enable": True}},
+                        },
+                    )
+                else:
+                    logging.info("GuardDuty is already enabled in the account " + account_number + ", region " + aws_region)
+
                 logging.info("Checking if GuardDuty detector publishes findings to S3.")
                 logging.info("ListPublishingDestinations API Call")
                 gd_destinations = guardduty.list_publishing_destinations(DetectorId=detector_id)["Destinations"]


### PR DESCRIPTION
Added functionality for ALE to enable suspended GuardDuty detectors with the `--guardduty` option. Previously only created a new detector if one did not exist.

Updated ALE role and documentation to reflect the new required permissions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
