### PR TITLE
Flow logs parquet

### DIFF
--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -80,7 +80,7 @@ def assisted_log_enabler():
     parser.add_argument('--exclude_accounts', metavar='ACCOUNT_NUMBERS', help=' Specify a comma separated list of AWS account numbers to EXCLUDE for multi_account mode.')
 
     function_parser_group = parser.add_argument_group('Single & Multi Account Options', 'Use these flags to choose which services you want to turn logging on for.')
-    function_parser_group.add_argument('--all', action='store_true', help=' Turns on all of the log types within the Assisted Log Enabler for AWS (does not include GuardDuty).')
+    function_parser_group.add_argument('--all', action='store_true', choices=['text', 'parquet'], help=' Turns on all of the log types within the Assisted Log Enabler for AWS (does not include GuardDuty).\nYou must select \'text\' or \'parquet\' as the log storage format for VPC Flow Logs.')
     function_parser_group.add_argument('--eks', action='store_true', help=' Turns on Amazon EKS audit & authenticator logs.')
     function_parser_group.add_argument('--vpcflow', choices=['text','parquet'], help=' Turns on Amazon VPC Flow Logs. Choose \'text\' or \'parquet\' as the format to store the flow logs.')
     function_parser_group.add_argument('--r53querylogs', action='store_true', help=' Turns on Amazon Route 53 Resolver Query Logs.')
@@ -136,7 +136,7 @@ def assisted_log_enabler():
         elif args.wafv2:
             ALE_single_account.run_wafv2_logs()
         elif args.all:
-            ALE_single_account.lambda_handler(event, context, bucket_name)
+            ALE_single_account.lambda_handler(event, context, bucket_name, args.vpcflow)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'multi_account':
@@ -162,7 +162,7 @@ def assisted_log_enabler():
         if args.eks:
             ALE_multi_account.run_eks(included_accounts, excluded_accounts)
         elif args.vpcflow:
-            ALE_multi_account.run_vpc_flow_logs(bucket_name, included_accounts, excluded_accounts,args.vpc_flow)
+            ALE_multi_account.run_vpc_flow_logs(bucket_name, included_accounts, excluded_accounts, args.vpc_flow)
         elif args.r53querylogs:
             ALE_multi_account.run_r53_query_logs(bucket_name, included_accounts, excluded_accounts)
         elif args.s3logs:
@@ -174,7 +174,7 @@ def assisted_log_enabler():
         elif args.wafv2:
             ALE_multi_account.run_wafv2_logs(included_accounts, excluded_accounts)
         elif args.all:
-            ALE_multi_account.lambda_handler(event, context, bucket_name, included_accounts, excluded_accounts)
+            ALE_multi_account.lambda_handler(event, context, bucket_name, included_accounts, excluded_accounts, args.vpc_flow)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'cleanup':

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -80,7 +80,7 @@ def assisted_log_enabler():
     parser.add_argument('--exclude_accounts', metavar='ACCOUNT_NUMBERS', help=' Specify a comma separated list of AWS account numbers to EXCLUDE for multi_account mode.')
 
     function_parser_group = parser.add_argument_group('Single & Multi Account Options', 'Use these flags to choose which services you want to turn logging on for.')
-    function_parser_group.add_argument('--all', action='store_true', choices=['text', 'parquet'], help=' Turns on all of the log types within the Assisted Log Enabler for AWS (does not include GuardDuty).\nYou must select \'text\' or \'parquet\' as the log storage format for VPC Flow Logs.')
+    function_parser_group.add_argument('--all', choices=['text','parquet'], help=' Turns on all of the log types within the Assisted Log Enabler for AWS (does not include GuardDuty).\nYou must select \'text\' or \'parquet\' as the log storage format for VPC Flow Logs.')
     function_parser_group.add_argument('--eks', action='store_true', help=' Turns on Amazon EKS audit & authenticator logs.')
     function_parser_group.add_argument('--vpcflow', choices=['text','parquet'], help=' Turns on Amazon VPC Flow Logs. Choose \'text\' or \'parquet\' as the format to store the flow logs.')
     function_parser_group.add_argument('--r53querylogs', action='store_true', help=' Turns on Amazon Route 53 Resolver Query Logs.')
@@ -136,7 +136,7 @@ def assisted_log_enabler():
         elif args.wafv2:
             ALE_single_account.run_wafv2_logs()
         elif args.all:
-            ALE_single_account.lambda_handler(event, context, bucket_name, args.vpcflow)
+            ALE_single_account.lambda_handler(event, context, bucket_name, args.all)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'multi_account':
@@ -174,7 +174,7 @@ def assisted_log_enabler():
         elif args.wafv2:
             ALE_multi_account.run_wafv2_logs(included_accounts, excluded_accounts)
         elif args.all:
-            ALE_multi_account.lambda_handler(event, context, bucket_name, included_accounts, excluded_accounts, args.vpc_flow)
+            ALE_multi_account.lambda_handler(event, context, bucket_name, included_accounts, excluded_accounts, args.all)
         else:
             logging.info("No valid option selected. Please run with -h to display valid options.")
     elif args.mode == 'cleanup':

--- a/assisted_log_enabler.py
+++ b/assisted_log_enabler.py
@@ -82,7 +82,7 @@ def assisted_log_enabler():
     function_parser_group = parser.add_argument_group('Single & Multi Account Options', 'Use these flags to choose which services you want to turn logging on for.')
     function_parser_group.add_argument('--all', action='store_true', help=' Turns on all of the log types within the Assisted Log Enabler for AWS (does not include GuardDuty).')
     function_parser_group.add_argument('--eks', action='store_true', help=' Turns on Amazon EKS audit & authenticator logs.')
-    function_parser_group.add_argument('--vpcflow', action='store_true', help=' Turns on Amazon VPC Flow Logs.')
+    function_parser_group.add_argument('--vpcflow', choices=['text','parquet'], help=' Turns on Amazon VPC Flow Logs. Choose \'text\' or \'parquet\' as the format to store the flow logs.')
     function_parser_group.add_argument('--r53querylogs', action='store_true', help=' Turns on Amazon Route 53 Resolver Query Logs.')
     function_parser_group.add_argument('--s3logs', action='store_true', help=' Turns on Amazon Bucket Logs.')
     function_parser_group.add_argument('--lblogs', action='store_true', help=' Turns on Amazon Load Balancer Logs.')
@@ -113,12 +113,16 @@ def assisted_log_enabler():
     included_accounts = 'all'
     excluded_accounts = 'none'
     if args.mode == 'single_account':
+
+
+
+
         if args.bucket:
             bucket_name = args.bucket
         if args.eks:
             ALE_single_account.run_eks()
         elif args.vpcflow:
-            ALE_single_account.run_vpc_flow_logs(bucket_name)
+            ALE_single_account.run_vpc_flow_logs(bucket_name,args.vpcflow)
         elif args.r53querylogs:
             ALE_single_account.run_r53_query_logs(bucket_name)
         elif args.s3logs:
@@ -158,7 +162,7 @@ def assisted_log_enabler():
         if args.eks:
             ALE_multi_account.run_eks(included_accounts, excluded_accounts)
         elif args.vpcflow:
-            ALE_multi_account.run_vpc_flow_logs(bucket_name, included_accounts, excluded_accounts)
+            ALE_multi_account.run_vpc_flow_logs(bucket_name, included_accounts, excluded_accounts,args.vpc_flow)
         elif args.r53querylogs:
             ALE_multi_account.run_r53_query_logs(bucket_name, included_accounts, excluded_accounts)
         elif args.s3logs:

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -161,7 +161,7 @@ def update_custom_bucket_policy(bucket_name, account_number, OrgAccountIdList):
         )
 
 # 4. Find VPCs and turn flow logs on if not on already.
-def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts):
+def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts,file_format):
     """Function to define the list of VPCs without logging turned on"""
     logging.info("Creating a list of VPCs without Flow Logs on.")
     for org_account in OrgAccountIdList:
@@ -224,7 +224,7 @@ def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_acco
                                 ]
                             }
                         ],
-                        DestinationOptions={'FileFormat':'parquet'}
+                        DestinationOptions={'FileFormat':file_format}
                     )
                     logging.info("VPC Flow Logs are turned on for account " + org_account + ".")
                 except Exception as exception_handle:
@@ -1002,7 +1002,7 @@ def run_eks(included_accounts='all', excluded_accounts='none'):
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
 
-def run_vpc_flow_logs(bucket_name='default', included_accounts='all', excluded_accounts='none'):
+def run_vpc_flow_logs(bucket_name='default', included_accounts='all', excluded_accounts='none',file_format='text'):
     """Function that runs the defined VPC Flow Log logging code"""
     OrgAccountIdList, organization_id = org_account_grab()
     account_number = get_account_number()

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -223,7 +223,8 @@ def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_acco
                                     },
                                 ]
                             }
-                        ]
+                        ],
+                        DestinationOptions={'FileFormat':'parquet'}
                     )
                     logging.info("VPC Flow Logs are turned on for account " + org_account + ".")
                 except Exception as exception_handle:

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -161,8 +161,9 @@ def update_custom_bucket_policy(bucket_name, account_number, OrgAccountIdList):
         )
 
 # 4. Find VPCs and turn flow logs on if not on already.
-def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts,file_format):
+def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts, file_format):
     """Function to define the list of VPCs without logging turned on"""
+    logging.info("Turning on VPC Flow Logs. Flow logs will be stored as" + file_format)
     logging.info("Creating a list of VPCs without Flow Logs on.")
     for org_account in OrgAccountIdList:
         if excluded_accounts != 'none' and org_account in excluded_accounts:
@@ -1064,7 +1065,7 @@ def run_wafv2_logs(included_accounts='all', excluded_accounts='none'):
     wafv2_logs(OrgAccountIdList, organization_id, included_accounts, excluded_accounts)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def lambda_handler(event, context, bucket_name='default', included_accounts='all', excluded_accounts='none'):
+def lambda_handler(event, context, bucket_name='default', included_accounts='all', excluded_accounts='none', file_format='text'):
     """Function that runs all of the previously defined functions"""
     unique_end = random_string_generator()
     account_number = get_account_number()
@@ -1073,7 +1074,7 @@ def lambda_handler(event, context, bucket_name='default', included_accounts='all
         bucket_name = create_bucket(OrgAccountIdList, account_number, unique_end)
     else:
         update_custom_bucket_policy(bucket_name, account_number, OrgAccountIdList)
-    flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts)
+    flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts, file_format)
     eks_logging(region_list, OrgAccountIdList, included_accounts, excluded_accounts)
     route_53_query_logs(region_list, OrgAccountIdList, bucket_name, included_accounts, excluded_accounts)
     s3_logs(region_list, account_number, OrgAccountIdList, unique_end, included_accounts, excluded_accounts)

--- a/subfunctions/ALE_multi_account.py
+++ b/subfunctions/ALE_multi_account.py
@@ -163,7 +163,7 @@ def update_custom_bucket_policy(bucket_name, account_number, OrgAccountIdList):
 # 4. Find VPCs and turn flow logs on if not on already.
 def flow_log_activator(OrgAccountIdList, region_list, bucket_name, included_accounts, excluded_accounts, file_format):
     """Function to define the list of VPCs without logging turned on"""
-    logging.info("Turning on VPC Flow Logs. Flow logs will be stored as" + file_format)
+    logging.info("Turning on VPC Flow Logs. Flow logs will be stored as " + file_format)
     logging.info("Creating a list of VPCs without Flow Logs on.")
     for org_account in OrgAccountIdList:
         if excluded_accounts != 'none' and org_account in excluded_accounts:

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -118,6 +118,7 @@ def update_custom_bucket_policy(bucket_name, account_number):
 def flow_log_activator(region_list, account_number, bucket_name, file_format):
     """Function that turns on the VPC Flow Logs, for VPCs identifed without them"""
     for aws_region in region_list:
+        logging.info("Turning on VPC Flow Logs. Flow logs will be stored as" + file_format)
         ec2 = boto3.client('ec2', region_name=aws_region)
         logging.info("Creating a list of VPCs without Flow Logs on in region " + aws_region + ".")
         try:
@@ -140,7 +141,6 @@ def flow_log_activator(region_list, account_number, bucket_name, file_format):
                 logging.info(no_logs + " does not have VPC Flow logging on. It will be turned on within this function.")
             logging.info("Activating logs for VPCs that do not have them turned on.")
             logging.info("If all VPCs have Flow Logs turned on, you will get an MissingParameter error. That is normal.")
-            logging.info("Creating FlowLos using " + file_format + " file format.")
             logging.info("CreateFlowLogs API Call")
             flow_log_on =  ec2.create_flow_logs(
                 ResourceIds=working_list,
@@ -898,7 +898,7 @@ def run_wafv2_logs():
     wafv2_logs()
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def lambda_handler(event, context, bucket_name='default'):
+def lambda_handler(event, context, bucket_name='default', file_format='text'):
     """Function that runs all of the previously defined functions"""
     unique_end = random_string_generator()
     account_number = sts.get_caller_identity()["Account"]

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -118,7 +118,7 @@ def update_custom_bucket_policy(bucket_name, account_number):
 def flow_log_activator(region_list, account_number, bucket_name, file_format):
     """Function that turns on the VPC Flow Logs, for VPCs identifed without them"""
     for aws_region in region_list:
-        logging.info("Turning on VPC Flow Logs. Flow logs will be stored as" + file_format)
+        logging.info("Turning on VPC Flow Logs. Flow logs will be stored as " + file_format)
         ec2 = boto3.client('ec2', region_name=aws_region)
         logging.info("Creating a list of VPCs without Flow Logs on in region " + aws_region + ".")
         try:
@@ -906,7 +906,7 @@ def lambda_handler(event, context, bucket_name='default', file_format='text'):
         bucket_name = create_bucket(unique_end)
     else:
         update_custom_bucket_policy(bucket_name, account_number)
-    flow_log_activator(region_list, account_number, bucket_name)
+    flow_log_activator(region_list, account_number, bucket_name, file_format)
     check_cloudtrail(account_number, bucket_name)
     eks_logging(region_list)
     route_53_query_logs(region_list, account_number, bucket_name)

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -115,7 +115,7 @@ def update_custom_bucket_policy(bucket_name, account_number):
         )
 
 # 2. Find VPCs and turn flow logs on if not on already.
-def flow_log_activator(region_list, account_number, bucket_name):
+def flow_log_activator(region_list, account_number, bucket_name, file_format):
     """Function that turns on the VPC Flow Logs, for VPCs identifed without them"""
     for aws_region in region_list:
         ec2 = boto3.client('ec2', region_name=aws_region)
@@ -140,6 +140,7 @@ def flow_log_activator(region_list, account_number, bucket_name):
                 logging.info(no_logs + " does not have VPC Flow logging on. It will be turned on within this function.")
             logging.info("Activating logs for VPCs that do not have them turned on.")
             logging.info("If all VPCs have Flow Logs turned on, you will get an MissingParameter error. That is normal.")
+            logging.info("Creating FlowLos using " + file_format + " file format.")
             logging.info("CreateFlowLogs API Call")
             flow_log_on =  ec2.create_flow_logs(
                 ResourceIds=working_list,
@@ -159,7 +160,7 @@ def flow_log_activator(region_list, account_number, bucket_name):
                         ]
                     }
                 ],
-                DestinationOptions={'FileFormat':'parquet'}
+                DestinationOptions={'FileFormat':file_format}
             )
             # Custom format specified in same order as documentation lists them at https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
             logging.info("VPC Flow Logs are turned on.")
@@ -851,13 +852,13 @@ def run_cloudtrail(bucket_name='default'):
     check_cloudtrail(account_number, bucket_name, custom_bucket)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
 
-def run_vpc_flow_logs(bucket_name='default'):
+def run_vpc_flow_logs(bucket_name='default', file_format='text'):
     """Function that runs the defined VPC Flow Log logging code"""
     if bucket_name == 'default':
         unique_end = random_string_generator()
         bucket_name = create_bucket(unique_end)
     account_number = sts.get_caller_identity()["Account"]
-    flow_log_activator(region_list, account_number, bucket_name)
+    flow_log_activator(region_list, account_number, bucket_name,file_format)
     logging.info("This is the end of the script. Please feel free to validate that logs have been turned on.")
     
 def run_r53_query_logs(bucket_name='default'):

--- a/subfunctions/ALE_single_account.py
+++ b/subfunctions/ALE_single_account.py
@@ -158,7 +158,8 @@ def flow_log_activator(region_list, account_number, bucket_name):
                             },
                         ]
                     }
-                ]
+                ],
+                DestinationOptions={'FileFormat':'parquet'}
             )
             # Custom format specified in same order as documentation lists them at https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
             logging.info("VPC Flow Logs are turned on.")


### PR DESCRIPTION
*Issue #, if available:*
#43 
*Description of changes:*
1) Added a requirement to choose "text" or "parquet" when selecting --all or --vpcflow.  Updated the help text accordingly. 
2) Added args.vpc_flow or args.all to .run_vpc_flow_logs() and .lambda_handler().  This sends the user's file format choice to those functions.
3) added file_format as a parameter to send to the flow_log_activator.  
4) In flow_log_activator - added "fileformat:file_format" at the end to select the file format in which to save the flow logs.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
